### PR TITLE
Refactor cease & revoke to standard submit method

### DIFF
--- a/features/back_office_cease_registration.feature
+++ b/features/back_office_cease_registration.feature
@@ -10,6 +10,6 @@ Feature: Back office user ceases a customers waste exemption activity
       And I complete a registration
 
   @happy_path
-  Scenario: Revoking registration by NCCC user
+  Scenario: Ceasing a registration by NCCC user
      When I cease a registration
      Then I will be informed the registration is deregistered

--- a/features/page_objects/deregistration_page.rb
+++ b/features/page_objects/deregistration_page.rb
@@ -1,23 +1,20 @@
 class DeregistrationPage < SitePrism::Page
 
-  element(:deregister_status_dropdown, "#admin_deregister_enrollment_form_reason")
+  element(:deregister_status_dropdown, "#admin_deregister_enrollment_exemption_form_status")
   element(:revoked_option, "option[value='revoked']")
   element(:ceased_option, "option[value='ceased']")
   element(:deregistration_comment, "#admin_deregister_enrollment_form_comment")
 
   element(:deregister_button, "input[name='commit']")
 
-  def revoke(args = {})
-    deregister_status_dropdown.click
-    revoked_option.click
-    deregistration_comment.set(args[:deregistration_comment]) if args.key?(:deregistration_comment)
+  def submit(args = {})
+    case args[:reason]
+    when :cease
+      ceased_option.select_option
+    when :revoke
+      revoked_option.select_option
+    end
 
-    deregister_button.click
-  end
-
-  def cease(args = {})
-    deregister_status_dropdown.click
-    ceased_option.click
     deregistration_comment.set(args[:deregistration_comment]) if args.key?(:deregistration_comment)
 
     deregister_button.click

--- a/features/step_definitions/back_office/edit_registration_steps.rb
+++ b/features/step_definitions/back_office/edit_registration_steps.rb
@@ -7,10 +7,10 @@ When(/^I revoke a registration$/) do
 
   @app.registration_details_page.deregister.click
 
-  @app.deregistration_page.revoke(
+  @app.deregistration_page.submit(
+    reason: :revoke,
     deregistration_comment: "This is a test"
   )
-
 end
 
 When(/^I cease a registration$/) do
@@ -21,7 +21,8 @@ When(/^I cease a registration$/) do
 
   @app.registration_details_page.deregister.click
 
-  @app.deregistration_page.cease(
+  @app.deregistration_page.submit(
+    reason: :cease,
     deregistration_comment: "This is a test"
   )
 end


### PR DESCRIPTION
Previously the deregistration page object had a `revoke()` and `cease()` method, which did the same thing only they selected a different value in the page's reason drop down.

This change refactors them into a single `submit()` method, with the reason passed in as an argument. This also brings the page inline with the standard pattern of each page object featuring a `submit()` which handles completing and submitting said page.