### PR TITLE
Refactor admin nav bar functions to Section

### DIFF
--- a/features/page_objects/admin_nav_bar_section.rb
+++ b/features/page_objects/admin_nav_bar_section.rb
@@ -1,0 +1,34 @@
+class AdminNavBarSection < SitePrism::Section
+
+  # IMPORTANT! Because of the way the nav-bar works in order to see the options
+  # you first have to click the relevant menu. For example to 'see' i.e. be able
+  # to click the export_option you first have to click on registrations_menu
+  # @app.search_page.nav_bar.registrations_menu.click
+  # @app.search_page.nav_bar.search_option.click
+  # This is just a factor of how bootstrap works.
+  #
+  # The CSS selectors were identified by using the Chrome addin
+  # http://selectorgadget.com/. You can also test them using the Chrome
+  # developer tools. Open them up, select the elements tab and then ctrl/cmd+f
+  # You should get an input field into which you can enter your selector and
+  # confirm/test its working. See
+  # https://developers.google.com/web/updates/2015/05/search-dom-tree-by-css-selector
+
+  # Finally the root selector for this section appears to be
+  # ".add-bottom-margin .container". So when adding it to you're pages use
+  # section(:nav_bar, AdminNavBarSection, ".add-bottom-margin .container")
+
+  element(:home_link, "a.navbar-brand")
+
+  element(:registrations_menu, ".dropdown:nth-child(1) .dropdown-toggle")
+  element(:search_option, ".dropdown-menu li:nth-child(1) a")
+  element(:new_option, ".dropdown-menu li:nth-child(2) a")
+  element(:export_option, ".dropdown-menu li~ li+ li a")
+
+  element(:users_menu, ".dropdown+ .dropdown .dropdown-toggle")
+  element(:view_users_option, ".dropdown-menu li:nth-child(1) a")
+  element(:invite_user_option, ".dropdown-menu li+ li a")
+
+  element(:sign_out_link, "a[href='/users/sign_out']")
+
+end

--- a/features/page_objects/deregistration_page.rb
+++ b/features/page_objects/deregistration_page.rb
@@ -7,6 +7,8 @@ class DeregistrationPage < SitePrism::Page
 
   element(:deregister_button, "input[name='commit']")
 
+  section(:nav_bar, AdminNavBarSection, ".add-bottom-margin .container")
+
   def submit(args = {})
     case args[:reason]
     when :cease

--- a/features/page_objects/registration_details_page.rb
+++ b/features/page_objects/registration_details_page.rb
@@ -2,4 +2,6 @@ class RegistrationDetailsPage < SitePrism::Page
 
   element(:deregister, "#deregister-enrollment")
 
+  section(:nav_bar, AdminNavBarSection, ".add-bottom-margin .container")
+
 end

--- a/features/page_objects/search_page.rb
+++ b/features/page_objects/search_page.rb
@@ -1,11 +1,5 @@
 class SearchPage < SitePrism::Page
 
-  element(:menu_home, :xpath, "html/body/header/div/div/a[2]")
-  element(:menu_registrations, :xpath, "html/body/header/div/nav/ul/li[1]/a")
-  element(:menu_search, :xpath, "html/body/header/div/nav/ul/li[1]/ul/li[1]/a")
-  element(:menu_new_registration, :xpath, "html/body/header/div/nav/ul/li[1]/ul/li[2]/a")
-  element(:sign_out, :xpath, "html/body/header/div/nav/ul/li[3]/a")
-
   element(:alert_signed_in, "div.alert-success[role='alert']", text: "successfully signed in")
   element(:alert_deregister, "div.alert-success[role='alert']", text: "Enrollment deregistered successfully")
 
@@ -18,6 +12,8 @@ class SearchPage < SitePrism::Page
   element(:search_button, ".btn-success")
 
   element(:first_search_result, ".h4 > a:first-child")
+
+  section(:nav_bar, AdminNavBarSection, ".add-bottom-margin .container")
 
   def submit(args = {})
     search_field.set(args[@exemption_number]) if args.key?(@exemption_number)

--- a/features/step_definitions/back_office/edit_registration_steps.rb
+++ b/features/step_definitions/back_office/edit_registration_steps.rb
@@ -1,8 +1,10 @@
 When(/^I revoke a registration$/) do
 
-  @app.search_page.menu_home.click
+  @app.search_page.nav_bar.home_link.click
+
   @app.search_page.search_field.set @exemption_number
   @app.search_page.search_button.click
+
   @app.search_page.first_search_result.click
 
   @app.registration_details_page.deregister.click
@@ -14,9 +16,12 @@ When(/^I revoke a registration$/) do
 end
 
 When(/^I cease a registration$/) do
-  @app.search_page.menu_home.click
+
+  @app.search_page.nav_bar.home_link.click
+
   @app.search_page.search_field.set @exemption_number
   @app.search_page.search_button.click
+
   @app.search_page.first_search_result.click
 
   @app.registration_details_page.deregister.click
@@ -31,6 +36,6 @@ Then(/^I will be informed the registration is deregistered$/) do
 
   expect(@app.registration_details_page.text).to include("Enrollment deregistered successfully")
 
-  @app.search_page.sign_out.click
+  @app.search_page.nav_bar.sign_out_link.click
 
 end

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -11,8 +11,8 @@ end
 # rubocop:disable Metrics/BlockLength
 When(/^I complete a registration$/) do
 
-  @app.search_page.menu_registrations.click
-  @app.search_page.menu_new_registration.click
+  @app.search_page.nav_bar.registrations_menu.click
+  @app.search_page.nav_bar.new_option.click
 
   @app.contact_details_page.submit(
     full_name: "Mr Test",


### PR DESCRIPTION
This change adds a [SitePrism section](https://github.com/natritmeyer/site_prism#sections) which contains all the logic needed for selecting the elements of the nav bar in the back office system.

A **SitePrism** section

> allows you to model sections of a page that appear on multiple pages or that appear a number of times on a page separately from Pages.

So in our case once a user is signed into the back office, the nav bar appears on every page. By creating a section object we can interact with the nav bar from each page, but maintain all the logic in one place.