### PR TITLE
Fix broken external new registration journeys

### DIFF
--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -20,10 +20,6 @@ end
 
 When(/^I register an exemption$/) do
 
-  @app.organisation_name_page.submit(
-    org_name: "Mr Test"
-  )
-
   @app.address_page.submit(
     postcode: "BS1 5AH",
     result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
@@ -43,7 +39,7 @@ When(/^I register an exemption$/) do
 
   @app.choose_exemptions_page.submit(
     tab: :using_waste,
-    exemption: "U1"
+    exemptions: %w(U1)
   )
 
   @app.check_details_page.submit


### PR DESCRIPTION
The current steps for the external user journeys were no longer working. This change fixs them.