### PR TITLE
Fix broken registration journeys v2!

### DIFF
--- a/features/deregister_registration.feature
+++ b/features/deregister_registration.feature
@@ -11,14 +11,14 @@ Feature: Back office users can 'deregister' the whole registration
 
   @happy_path
   Scenario: Revoking a registration with multiple exemptions
-     When I have a registration with the exemptions "S1, D2"
+     When I have a registration with the exemptions "D2, S1"
       And I "revoke" the registration
      Then I can see all exemptions are "Revoked"
       And I can also see the registration is "Revoked"
 
   @happy_path
   Scenario: Ceasing a registration with multiple exemptions
-     When I have a registration with the exemptions "S1, D2"
+     When I have a registration with the exemptions "D2, S1"
       And I "cease" the registration
      Then I can see all exemptions are "Ceased"
       And I can also see the registration is "Ceased"

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -49,7 +49,7 @@ When(/^I complete a registration$/) do
   )
 
   @app.choose_exemptions_page.submit(
-    exemptions: %w(S1 D2)
+    exemptions: %w(D2 S1)
   )
 
   @app.check_details_page.submit
@@ -100,7 +100,7 @@ When(/^I complete a registration using postcode (.*) for the site address$/) do 
   )
 
   @app.choose_exemptions_page.submit(
-    exemptions: %w(S1 D2)
+    exemptions: %w(D2 S1)
   )
 
   @app.check_details_page.submit

--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -39,7 +39,7 @@ When(/^I register an exemption$/) do
 
   @app.choose_exemptions_page.submit(
     tab: :using_waste,
-    exemptions: %w(U1)
+    exemptions: %w(S1)
   )
 
   @app.check_details_page.submit
@@ -62,7 +62,7 @@ When(/^I register an exemption for a|my partnership$/) do
   )
 
   @app.choose_exemptions_page.submit(
-    exemptions: %w(S1 D2)
+    exemptions: %w(D2 S1)
   )
 
   @app.check_details_page.submit


### PR DESCRIPTION
Having fixed the journeys in 05f9102 we then also deployed the latest version of WEX, which then broke the journeys again!

This was because of a change in behaviour to the choose exemptions page. Now clicking submit on moves you to the next page if you are on the last tab (storing waste), else it just moves you to the next tab.

Because of this any step which selected an exemption which wasn't on the last tab, or which selected and **S1** followed by a **D2** would put the user in a tab that wasn't the last. Clicking submit then would only move the user to the next tab, whereas the tests assume you have moved to the next page.

This change fixes these issue.