### PR TITLE
Fix BO site address with NGR feature examples

### DIFF
--- a/features/backoffice_site_address.feature
+++ b/features/backoffice_site_address.feature
@@ -26,7 +26,6 @@ Feature: National grid reference and site area details are found from site postc
      Then I will see the EA admin area is set to <area>
 
      Examples:
-     | ngr           | area                                         |
-     | SD4261205201  | Greater Manchester Merseyside and Cheshire   |
-     | NY2435912477  | Cumbria and Lancashire                       |
-     
+     | ngr           | area                                       |
+     | SD4261205201  | Cumbria and Lancashire                     |
+     | SJ6206087294  | Greater Manchester Merseyside and Cheshire |


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WAS-1149

We initially thought that a fix we had put in place for this issue (enter a site using an NGR and the EA admin area doesn't get updated) wasn't working because scenario *Registration by a NCCC user using a National Grid reference (NGR) for site address - area is added to registration* was failing.

However upon investigation we found it was actually bum data in the test itself; the area name was wrong for the NGR used.

This simply corrects the scenario example data.