### PR TITLE
Move page object sections into '/sections' folder

### DIFF
--- a/features/page_objects/confirmation_letter_bulk_exports_page.rb
+++ b/features/page_objects/confirmation_letter_bulk_exports_page.rb
@@ -1,3 +1,5 @@
+require_relative "sections/admin_nav_bar_section"
+
 class ConfirmationLetterBulkExportsPage < SitePrism::Page
 
   element(:export_alert, "div.alert-success[role='alert']")

--- a/features/page_objects/deregister_exemption_page.rb
+++ b/features/page_objects/deregister_exemption_page.rb
@@ -1,3 +1,5 @@
+require_relative "sections/admin_nav_bar_section"
+
 class DeregisterExemptionPage < SitePrism::Page
 
   element(:reason_dropdown, "#admin_deregister_enrollment_exemption_form_status")

--- a/features/page_objects/deregister_registration_page.rb
+++ b/features/page_objects/deregister_registration_page.rb
@@ -1,3 +1,5 @@
+require_relative "sections/admin_nav_bar_section"
+
 class DeregisterRegistrationPage < SitePrism::Page
 
   element(:alert_registration_dereg, "div.alert-success[role='alert']", text: "Enrollment deregistered successfully")

--- a/features/page_objects/enrollment_exports_page.rb
+++ b/features/page_objects/enrollment_exports_page.rb
@@ -1,3 +1,5 @@
+require_relative "sections/admin_nav_bar_section"
+
 class EnrollmentExportsPage < SitePrism::Page
 
   element(:export_alert, "div.alert-success[role='alert']")

--- a/features/page_objects/registration_page.rb
+++ b/features/page_objects/registration_page.rb
@@ -1,10 +1,15 @@
+require_relative "sections/admin_nav_bar_section"
+require_relative "sections/exemption_details_section"
+require_relative "sections/location_details_section"
+require_relative "sections/registration_details_section"
+
 class RegistrationPage < SitePrism::Page
 
   element(:deregister_btn, "#deregister-enrollment")
 
   section(:nav_bar, AdminNavBarSection, AdminNavBarSection::SELECTOR)
-  section(:registration_details, RegistrationDetailsSection, RegistrationDetailsSection::SELECTOR)
   section(:exemption_details, ExemptionDetailsSection, ExemptionDetailsSection::SELECTOR)
+  section(:registration_details, RegistrationDetailsSection, RegistrationDetailsSection::SELECTOR)
   section(:site_details, LocationDetailsSection, LocationDetailsSection::SELECTOR)
 
 end

--- a/features/page_objects/registration_page.rb
+++ b/features/page_objects/registration_page.rb
@@ -1,7 +1,7 @@
 require_relative "sections/admin_nav_bar_section"
 require_relative "sections/exemption_details_section"
-require_relative "sections/location_details_section"
 require_relative "sections/registration_details_section"
+require_relative "sections/site_details_section"
 
 class RegistrationPage < SitePrism::Page
 
@@ -9,7 +9,7 @@ class RegistrationPage < SitePrism::Page
 
   section(:nav_bar, AdminNavBarSection, AdminNavBarSection::SELECTOR)
   section(:exemption_details, ExemptionDetailsSection, ExemptionDetailsSection::SELECTOR)
+  section(:site_details, SiteDetailsSection, SiteDetailsSection::SELECTOR)
   section(:registration_details, RegistrationDetailsSection, RegistrationDetailsSection::SELECTOR)
-  section(:site_details, LocationDetailsSection, LocationDetailsSection::SELECTOR)
 
 end

--- a/features/page_objects/sections/admin_nav_bar_section.rb
+++ b/features/page_objects/sections/admin_nav_bar_section.rb
@@ -17,7 +17,7 @@ class AdminNavBarSection < SitePrism::Section
   # When adding it to your pages use
   # section(:nav_bar, AdminNavBarSection, AdminNavBarSection::SELECTOR)
 
-  SELECTOR = ".add-bottom-margin .container".freeze
+  SELECTOR ||= ".add-bottom-margin .container".freeze
 
   element(:home_link, "a.navbar-brand")
 

--- a/features/page_objects/sections/exemption_details_section.rb
+++ b/features/page_objects/sections/exemption_details_section.rb
@@ -13,7 +13,7 @@ class ExemptionDetailsSection < SitePrism::Section
   # When adding it to your pages use
   # section(:exemption_details, ExemptionDetailsSection, ExemptionDetailsSection::SELECTOR)
 
-  SELECTOR = ".col-sm-9 .row:nth-child(3) .panel-default".freeze
+  SELECTOR ||= ".col-sm-9 .row:nth-child(3) .panel-default".freeze
 
   element(:expander_link, "a[href='#exemption-details']")
 

--- a/features/page_objects/sections/location_details_section.rb
+++ b/features/page_objects/sections/location_details_section.rb
@@ -13,7 +13,7 @@ class LocationDetailsSection < SitePrism::Section
   # When adding it to your pages use
   # section(:site_details, LocationDetailsSection, LocationDetailsSection::SELECTOR)
 
-  SELECTOR = ".col-sm-9 .row:nth-child(4) .panel-default".freeze
+  SELECTOR ||= ".col-sm-9 .row:nth-child(4) .panel-default".freeze
 
   element(:expander_link, "a[href='#site-details']")
 

--- a/features/page_objects/sections/registration_details_section.rb
+++ b/features/page_objects/sections/registration_details_section.rb
@@ -11,7 +11,7 @@ class RegistrationDetailsSection < SitePrism::Section
   # When adding it to your pages use
   # section(:registration_details, RegistrationDetailsSection, RegistrationDetailsSection::SELECTOR)
 
-  SELECTOR = ".col-sm-9 .row:nth-child(2) .panel-default".freeze
+  SELECTOR ||= ".col-sm-9 .row:nth-child(2) .panel-default".freeze
 
   element(:expander_link, "a[href='#registration-details']")
 

--- a/features/page_objects/sections/site_details_section.rb
+++ b/features/page_objects/sections/site_details_section.rb
@@ -1,4 +1,4 @@
-class LocationDetailsSection < SitePrism::Section
+class SiteDetailsSection < SitePrism::Section
 
   # IMPORTANT! The section is hidden when the page is first loaded you, so to
   # see its details you first need to click 'it'. For example to 'see' i.e. be
@@ -11,7 +11,7 @@ class LocationDetailsSection < SitePrism::Section
   # This is just a factor of how bootstrap works.
   #
   # When adding it to your pages use
-  # section(:site_details, LocationDetailsSection, LocationDetailsSection::SELECTOR)
+  # section(:site_details, SiteDetailsSection, SiteDetailsSection::SELECTOR)
 
   SELECTOR ||= ".col-sm-9 .row:nth-child(4) .panel-default".freeze
 


### PR DESCRIPTION
This change moves the all classes in the `/page_objects` folder that inherit from `SitePrism::Section` into their own `/page_objects/sections` folder.

This will help improve maintenance (the fact we use sections and where to find them is now obvious), but is also part of sorting issue #9 . The issue is when you have a page object called `RegistrationPage`, and you want to use something in the same folder called `SiteDetailsSection`, you can't because of the order in which they are loaded.

Placing them into a separate folder forces us to use `require_relative`, which in turn resolves the issue of the order the classes are loaded (it no longer matters).

Finally because of the way things are loaded into a Cucumber environment, we found placing multiple `require_relative`'s to the same class was causing the following message to appear in the output; `warning: already initialized constant SiteDetailsSection::SELECTOR`. Memoizing was felt to be a perfectly safe solution, as we know this is just a result of loading the same class multiple times. See http://stackoverflow.com/a/23552366/6117745