### PR TITLE
Updated confirmation letter page test 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,14 +7,14 @@ GEM
       io-like (~> 0.3.0)
     ast (2.3.0)
     builder (3.2.3)
-    capybara (2.12.0)
+    capybara (2.12.1)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    childprocess (0.6.1)
+    childprocess (0.6.2)
       ffi (~> 1.0, >= 1.0.11)
     chromedriver-helper (1.0.0)
       archive-zip (~> 0.7.0)
@@ -78,7 +78,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
-    rubyzip (1.2.0)
+    rubyzip (1.2.1)
     selenium-webdriver (2.53.4)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
@@ -103,4 +103,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.13.6
+   1.13.7

--- a/features/confirmation_letters_export.feature
+++ b/features/confirmation_letters_export.feature
@@ -8,7 +8,7 @@ Feature: Back office users can create confirmation letter exports
     Given I am an internal user
       And I have a valid username and password
 
-  @happy_path
   Scenario: Back office user exports confirmation letters
      When I export confirmation letters for today
-     Then I will see the confirmation letter export status as complete
+     Then I will see the confirmation letter export is successfully completed
+      And I will see the filename of the export

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -291,7 +291,7 @@ Then(/^I will see the exported registrations file status as complete$/) do
   expect(@app.enrollment_exports_page.latest_export_status.text).to eq("Complete")
 end
 
-Then(/^I will see the confirmation letter export status as complete$/) do
+Then(/^I will see the confirmation letter export is successfully completed$/) do
 
   refresh_cnt = 0
   loop do
@@ -307,4 +307,9 @@ Then(/^I will see the confirmation letter export status as complete$/) do
   # Asserts export has been run and doesn't have any validation errors
   # if this is not run we could have a false postitive check of success
   expect(@app.confirmation_letter_bulk_exports_page.latest_export_status.text).to eq("Complete")
+end
+
+Then(/^I will see the filename of the export$/) do
+  pending # Write code here that turns the phrase above into concrete actions
+  # expect(@app.confirmation_letter_bulk_exports_page.latest_export_file.text).not_to eq("n/a")
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WAS-1152

We recently put the confirmation letter generation feature live, however when testing the bulk letter export we spotted an issue only after it had ben released.

Assume today is 3 March 2017. If I was to add a registration (and only one) and then go to the bulk letter export, and select 2017-03-03 to 2017-03-03 it would say there were no registrations to export.

Selecting 2017-03-02 to 2017-03-03 doesn't help either. It would therefore seem that the bulk letter export only works for registrations created prior to the current date.

So we have updated the `Back office user exports confirmation letters` scenario in `confirmation_letters_export.feature` with an additional step that will check that the filename is set to something other than 'n/a', as this will confirm that the registration was included in the export. However we have set it to pending for now as this is a known issue we want to fix, but we don't want it causing the acceptance tests when run in our CI environments to fail.