### PR TITLE
Add exclusion for _steps.rb from blocklength rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,13 @@ Style/EmptyLinesAroundBlockBody:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
+# Steps aren't like traditional methods and don't benefit from being broken
+# down. Therefore we exclude them from the block length metric as they often can
+# be long.
+Metrics/BlockLength:
+  Exclude:
+    - "**/features/step_definitions/**/*_steps.rb"
+
 # We believe the default of 10 lines for a method length is too restrictive and
 # often quickly hit just because we need to specify the namesspace, class and
 # method before then doing something with it.

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -8,7 +8,6 @@ Given(/^I have a valid username and password$/) do
 
 end
 
-# rubocop:disable Metrics/BlockLength
 When(/^I complete a registration$/) do
 
   @app.search_page.nav_bar.registrations_menu.click
@@ -59,9 +58,7 @@ When(/^I complete a registration$/) do
   @exemption_number = @app.confirmation_page.ref_no.text
 
 end
-# rubocop:enable Metrics/BlockLength
 
-# rubocop:disable Metrics/BlockLength
 When(/^I complete a registration using postcode (.*) for the site address$/) do |postcode|
   @app.search_page.nav_bar.registrations_menu.click
   @app.search_page.nav_bar.new_option.click
@@ -109,9 +106,7 @@ When(/^I complete a registration using postcode (.*) for the site address$/) do 
   @exemption_number = @app.confirmation_page.ref_no.text
 
 end
-# rubocop:enable Metrics/BlockLength
 
-# rubocop:disable Metrics/BlockLength
 When(/^I complete a registration using a national grid reference (.*) for the site address$/) do |ngr|
   @app.search_page.nav_bar.registrations_menu.click
   @app.search_page.nav_bar.new_option.click
@@ -160,9 +155,7 @@ When(/^I complete a registration using a national grid reference (.*) for the si
 
   @exemption_number = @app.confirmation_page.ref_no.text
 end
-# rubocop:enable Metrics/BlockLength
 
-# rubocop:disable Metrics/BlockLength
 Given(/^I have a registration with the exemptions "([^"]*)"$/) do |exemptions|
 
   @app.search_page.nav_bar.registrations_menu.click
@@ -216,7 +209,6 @@ Given(/^I have a registration with the exemptions "([^"]*)"$/) do |exemptions|
   @exemption_number = @app.confirmation_page.ref_no.text
 
 end
-# rubocop:enable Metrics/BlockLength
 
 Then(/^I will see the EA admin area is set to (.*)$/) do |area|
   @app.search_page.nav_bar.home_link.click


### PR DESCRIPTION
Steps unlike normal code is not something we particularly want to break down into smaller subroutines. Particularly where a step is 'complete a registration' they can therefore become very long.

Rather than keep adding specific exclusions to each impacted step, this adds an exclusion to the projects `.rubocop.yml` file to cover all `_steps.rb` files in the `features/step_definitions` folder.