### PR TITLE
Fix failing register as a partnership scenario

### DIFF
--- a/features/page_objects/correspondence_contact_page.rb
+++ b/features/page_objects/correspondence_contact_page.rb
@@ -16,7 +16,7 @@ class CorrespondenceContactPage < SitePrism::Page
   def submit(args = {})
     tel_number.set(args[:tel_number]) if args.key?(:tel_number)
     full_name.set(args[:full_name]) if args.key?(:full_name)
-
+    premises.set(args[:premises]) if args.key?(:premises)
     submit_button.click
   end
 

--- a/features/step_definitions/front_office/partnership_steps.rb
+++ b/features/step_definitions/front_office/partnership_steps.rb
@@ -35,6 +35,7 @@ When(/^I register an exemption for a|my partnership$/) do
 
   @app.correspondence_contact_page.submit(
     full_name: "Mr Test",
+    premises: "Test house",
     tel_number: "01234567899"
   )
 


### PR DESCRIPTION
Scenario 'Registration by a partnership' in `register_new_exemption.feature` was failing. After investigation it was identified that a new address is now returned by OS Places when using the postcode BS1 5AH. We use this address of the first partner to pre-populate the correspondance address, however `premises` is a mandatory field on that screen and this new address was missing it.

So this change simply passes in a set premises name to use when completing the correspondance details as part of the scenario.