### PR TITLE
Attempt to fix broken auto acp. test in env's

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,13 @@ gem "rubocop", require: false
 # Rake gives us the ability to create our own commands or 'tasks' for working
 # with quke.
 gem "rake"
+
+# We don't actually need a reference to chromedriver-helper for this project;
+# quke itself brings it in. However when CDH updated to 1.1.0 and this project
+# took the change (thanks to an automated PR from Deppbot) we found it would no
+# longer run in our dev, qa and pre-prod environments.
+# This is because the versions of chromedriver actually on our jenkins slave
+# the one referred to in this update are no longer the same.
+# Hence by referring to it here we can lock the version to one we know allows
+# this project to run in our environments.
+gem "chromedriver-helper", "1.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
       xpath (~> 2.0)
     childprocess (0.8.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (1.1.0)
+    chromedriver-helper (1.0.0)
       archive-zip (~> 0.7.0)
       nokogiri (~> 1.6)
     cliver (0.3.2)
@@ -99,10 +99,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  chromedriver-helper (= 1.0.0)
   quke
   rake
   rubocop
 
-
 BUNDLED WITH
-   1.13.7
+   1.15.1


### PR DESCRIPTION
Having recently tried to run an updated version of this project in our pre-production environment we have found it to no longer work. The current belief is because the chromedriver version of the project is now no longer in sync with that installed on our Jenkins slave it can no longer connect and run.

This change locks the version of `chromedriver-helper` to one we know that works in our environments.