### PR TITLE
Add workaround for tests failing in pre-prod env

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,22 @@ You can figure how the project runs using [Quke config files](https://github.com
 touch .config.yml
 ```
 
-Into that file you'll need to add the `app_host:` entry, with the url of the FRAE environment you wish to test against.
+Into that file you'll need to add the `app_host:` entry, with the url of the WEX environment you wish to test against.
 
 If left as that by default when **Quke** is executed it will run against your selected environment using the headless browser **PhantomJS**.
+
+### Custom WEX config
+
+Recently we have needed to add special logic for running the tests in our environments (dev, QA and Pre-prod). Though fine locally tests are failing if the a submit button is 'off the page' i.e. you would need to scroll to click it. Because of this when setting up the tests to run automatically from the Jenkins slave you will need to add the following to the `.config.yml`.
+
+```yaml
+custom:
+  window_size:
+    width: 1000
+    height: 2000
+```
+
+The project now includes logic to look for this and if present will resize the window accordingly. Ideally this situation should be periodically tested to see if this workaround is still required.
 
 ### Back office
 

--- a/features/hooks/before.rb
+++ b/features/hooks/before.rb
@@ -1,0 +1,18 @@
+Before do
+  # As of 2017-10-30 it appears that tests do not complete in our environments
+  # if an element is not visible on the page. This should not be a problem and
+  # cannot be replicated locally, however has been confirmed in our pre-prod
+  # environment. The error we get is
+  # Element is not clickable at point (592.5, 23).
+  # The element in question is the continue (submit) button which on certain
+  # pages using the default screen size is out of view.
+  # Therefore we've added this functionality that looks for a custom
+  # window_size element on the config object and if present, sets the window
+  # size at the start of each test
+  if Quke::Quke.config.custom && Quke::Quke.config.custom["window_size"]
+    Capybara.current_session.current_window.resize_to(
+      Quke::Quke.config.custom["window_size"]["width"],
+      Quke::Quke.config.custom["window_size"]["height"]
+    )
+  end
+end


### PR DESCRIPTION
As of writing it was 8 months since we had run the acceptance tests in our environments. When attempting to deploy an update recently the acceptance tests would not connect to the chromedriver.

We were able to resolve that by putting pack the version of the chromer-driver-helper gem used by the project, but then found that the tests would fail on any page where the submit button was not visible in the window i.e. you would have to scroll to reach it.

We could not explain why this has happened (the content of the pages has not changed and only minor updates to the projects dependencies has taken place) but were able to get the tests passing if we resized the window such that the continue button is always visible.

This change includes the functionality for that workaround.