### PR TITLE
Fix back office user credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,16 @@ You can figure how the project runs using [Quke config files](https://github.com
 touch .config.yml
 ```
 
-Into that file you'll need to add the `app_host:` entry, with the url of the WEX environment you wish to test against.
+Into that file you'll need to add as a minimum this, replacing the example values with ones relevant to the environment under test.
+
+```yaml
+app_host: 'https://urlofenvironmenttotest.example.com'
+custom:
+  accounts:
+    SystemUser:
+      username: system.user@example.com
+      password: SystemUserPassword1
+```
 
 If left as that by default when **Quke** is executed it will run against your selected environment using the headless browser **PhantomJS**.
 

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -2,8 +2,8 @@ Given(/^I have a valid username and password$/) do
 
   # Back office login page
   @app.login_page.submit(
-    email: "tim.stone.ea@gmail.com",
-    password: "Abcde12345"
+    email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
+    password: Quke::Quke.config.custom["accounts"]["SystemUser"]["password"]
   )
 
 end


### PR DESCRIPTION
Recent runs of the acceptance tests have been failing, and upon investigation it looks like this is because the previous credentials no longer work.

This change brings in the new way of holding credentials i.e. we no longer commit them to source control and behind the scenes we've updated the credentials.