### PR TITLE
Unpin chromedriver-helper version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,13 +9,3 @@ gem "rubocop", require: false
 # Rake gives us the ability to create our own commands or 'tasks' for working
 # with quke.
 gem "rake"
-
-# We don't actually need a reference to chromedriver-helper for this project;
-# quke itself brings it in. However when CDH updated to 1.1.0 and this project
-# took the change (thanks to an automated PR from Deppbot) we found it would no
-# longer run in our dev, qa and pre-prod environments.
-# This is because the versions of chromedriver actually on our jenkins slave
-# the one referred to in this update are no longer the same.
-# Hence by referring to it here we can lock the version to one we know allows
-# this project to run in our environments.
-gem "chromedriver-helper", "1.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    archive-zip (0.7.0)
+    archive-zip (0.11.0)
       io-like (~> 0.3.0)
     ast (2.4.0)
     browserstack-local (1.3.0)
@@ -17,9 +17,9 @@ GEM
       xpath (>= 2.0, < 4.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (1.0.0)
-      archive-zip (~> 0.7.0)
-      nokogiri (~> 1.6)
+    chromedriver-helper (1.2.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     cliver (0.3.2)
     cucumber (2.99.0)
       builder (>= 2.1.2)
@@ -100,11 +100,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  chromedriver-helper (= 1.0.0)
   quke
   rake
   rubocop
 
-
 BUNDLED WITH
-   1.15.1
+   1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
-    parser (2.5.0.4)
+    parser (2.5.1.0)
       ast (~> 2.4.0)
     poltergeist (1.17.0)
       capybara (~> 2.1)


### PR DESCRIPTION
Previously we had to pin it to an older version in order to match the versions installed in our Jenkins CI environment.

However they have now been updated so the tests no longer run. This change removes the pinning and updates the version so we match what is now in our Jenkins CI environment.