### PR TITLE
updating tests to use updated configuration file

### DIFF
--- a/.config-ci.yml
+++ b/.config-ci.yml
@@ -1,0 +1,17 @@
+
+custom:
+  accounts:
+    DataAgent:
+      username: data_agent_user@example.gov.uk
+    AdminAgent:
+      username: admin_agent_user@example.gov.uk
+    SuperAgent:
+      username: super_agent_user@example.gov.uk
+    SystemUser:
+      username: system_user@example.gov.uk
+  
+  urls:
+    front_office: "http://example.com"
+    back_office: "http://example.com"
+
+

--- a/.config_Chrome70_OSX.yml
+++ b/.config_Chrome70_OSX.yml
@@ -1,0 +1,166 @@
+# The standard place to add your features and step_definitions is in a folder
+# named 'features' at the root of the project. However if you'd like to name
+# this folder something else, you can tell Quke what the new name is here.
+# The default is features
+# features_folder: 'cukes'
+
+# Normally Capybara expects to be testing an in-process Rack application, but
+# we're using it to talk to a remote host. Users of Quke can set what this
+# will be by simply setting `app_host`. You can then use it directly using
+# Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
+# the full url each time
+app_host: 'http://localhost:3000'
+
+# Tells Quke which browser to use for testing. Choices are firefox, chrome
+# browserstack and phantomjs, with the default being phantomjs
+driver: browserstack
+
+# Add a pause (in seconds) between steps so you can visually track how the
+# browser is responding. Only useful if using a non-headless browser. The
+# default is 0
+pause: 0
+
+# Specify whether Quke should stop all tests once an error occurs. Useful in
+# Continuous Integration (CI) environments where a quick Yes/No is preferable to
+# a detailed response.
+stop_on_error: 2
+
+# Capybara will attempt to find an element for a period of time, rather than
+# immediately failing because the element cannot be found. This defaults to 2
+# seconds. However if the site you are working with is slow or features
+# elements that take some time to load you can increase this default.
+max_wait_time: 5
+
+# Tell the driver Quke is using to send a different user-agent value to the site
+# under test. Useful if you want the underlying driver to spoof what kind of
+# browser the request is coming from. For example you may want to pretend to be
+# a mobile browser so you can check what you get back versus the desktop
+# version. Or you want to pretend to be another kind of browser, because the one
+# you have is not supported by the site.
+# user_agent: "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)"
+
+# Currently only supported when using the phantomjs driver (ignored by the
+# others). In phantomjs if a site has a javascript error we can configure it
+# to throw an error which will cause the test to fail. Quke by default sets this
+# to true, however you can override it by setting this flag to false.
+# For example you may be dealing with a legacy site and JavaScript errors
+# are out of your scope. You still want to test other aspects of the site
+# but not let these errors prevent you from using phantomjs.
+javascript_errors: false
+
+# Anything you place under the 'custom' node in the `.config.yml` file will be
+# available within your steps and page objects by calling
+# `Quke::Quke.config.custom`. So using the example below we could access its
+# values in the following ways
+#
+# Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
+# Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+#
+# As long as what you add is valid YAML (check with a tool like
+# http://www.yamllint.com/) Quke will be able to pick it up and make it
+# available in your tests.
+custom:
+  accounts:
+    DataAgent:
+      username: data_agent_user@example.gov.uk
+    AdminAgent:
+      username: admin_agent_user@example.gov.uk
+    SuperAgent:
+      username: super_agent_user@example.gov.uk
+    SystemUser:
+      username: system_user@example.gov.uk
+
+
+# Local setup    
+  urls:
+    front_office: "http://localhost:3000"
+    back_office: "http:/localhost:3001"
+
+
+# If you are running Quke behind a proxy you can configure the proxy details
+# here. You'll need either the hostname or IP of the proxy server (don't include
+# the http:// bit) and the port number (typically 8080). Currently proxy
+# settings will only be applied if you are using the PhantomJS, Chrome or
+# Firefox drivers.
+# proxy:
+#   host: '10.10.2.70'
+#   port: 8080
+  # In some cases you may also need to tell the browser (driver) not to use the
+  # proxy for local or specific connections. For this simply provide a comma
+  # separated list of addresses.
+  #
+  # IMPORTANT NOTE! phantomjs does not currently support this option. If you
+  # have to go via a proxy server for external connections, but not local ones
+  # you will be limited to using either the Chrome or Firefox drivers.
+  # no_proxy: '127.0.0.1,192.168.0.1'
+
+# If you select the browserstack driver, there are a number of options you
+# can pass through to setup your browserstack tests, username and auth_key
+# being the critical ones.
+# Please see https://www.browserstack.com/automate/capabilities for more details
+browserstack:
+  # To run your tests with browserstack you must provide a username and auth_key
+  # as a minimum.
+  # If you don't want to put these credentials in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variables BROWSERSTACK_USERNAME and BROWSERSTACK_AUTH_KEY
+  # username: 
+  # auth_key: 
+
+  # If you want to use local testing you must provide a key. You can find this
+  # in Browserstack once logged in under settings. Its typically the same value
+  # as the auth_key above.
+  # If you don't want to put this credential in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variable BROWSERSTACK_LOCAL_KEY
+  # local_key: 
+
+  # Anything set under capabilities will be passed directly by Quke to
+  # browserstack as means of configuring the test.
+  # So the config keys (e.g. build, project, name) you set should match a real
+  # browserstack capability, and the value exist in the range it expects. See
+  # for further reference on browserstack capabilities
+  # https://www.browserstack.com/automate/capabilities
+  # https://www.browserstack.com/automate/ruby#configure-capabilities
+  capabilities:
+    # Keep track of all your automated tests using the build and project
+    # capabilities. Group your tests into builds, and builds further into
+    # projects
+    project: 'Waste exemptions'
+    build: 'Start renewal'
+    # Allows you to specify an identifier for the test run.
+    # If you intend to repeat a test this might not be that applicable, but in
+    # the case of one off tests it might be useful
+    # name: 'Removing key person'
+
+    # To avoid invalid certificate errors while testing set acceptSslCerts to
+    # true. This is not listed on the general capabilities page but is here
+    # https://www.browserstack.com/automate/ruby#self-signed-certificates
+    acceptSslCerts: true
+    # Required if you want to generate screenshots at various steps in your test
+    # test. Browserstack default is false
+    browserstack.debug: false
+    # Required if you want to enable video recording during your test.
+    # Browserstack default is true
+    browserstack.video: true
+    # Required if you need to test a locally hosted (e.g. http://localhost:300)
+    # or private internal web site. Browserstack has a feature called local
+    # testing that Quke also supports, but to use
+    # - Browserstack must be your selected driver
+    # - You must have set local_key above
+    # - You must this value to true
+    browserstack.local: true
+    # Another setting not listed, setting the following will prevent any values
+    # you pass in, for example when filling in a form, from appearing in the
+    # logs. General use case is to prevent passwords being exposed, but beware
+    # that all input will be masked in the logs if set.
+    browserstack.maskSendKeys: true
+
+    # https://www.browserstack.com/automate/capabilities
+    browser: Chrome
+    os: 'OS X'
+    browser_version: '70.0'
+    os_version: 'Mojave'
+    # adding native events to help with clicking label instead of opaque radio button
+    nativeEvents: 'true'

--- a/.config_Chrome70_W10.yml
+++ b/.config_Chrome70_W10.yml
@@ -1,0 +1,166 @@
+# The standard place to add your features and step_definitions is in a folder
+# named 'features' at the root of the project. However if you'd like to name
+# this folder something else, you can tell Quke what the new name is here.
+# The default is features
+# features_folder: 'cukes'
+
+# Normally Capybara expects to be testing an in-process Rack application, but
+# we're using it to talk to a remote host. Users of Quke can set what this
+# will be by simply setting `app_host`. You can then use it directly using
+# Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
+# the full url each time
+app_host: 'http://localhost:3000'
+
+# Tells Quke which browser to use for testing. Choices are firefox, chrome
+# browserstack and phantomjs, with the default being phantomjs
+driver: browserstack
+
+# Add a pause (in seconds) between steps so you can visually track how the
+# browser is responding. Only useful if using a non-headless browser. The
+# default is 0
+pause: 0
+
+# Specify whether Quke should stop all tests once an error occurs. Useful in
+# Continuous Integration (CI) environments where a quick Yes/No is preferable to
+# a detailed response.
+stop_on_error: 2
+
+# Capybara will attempt to find an element for a period of time, rather than
+# immediately failing because the element cannot be found. This defaults to 2
+# seconds. However if the site you are working with is slow or features
+# elements that take some time to load you can increase this default.
+max_wait_time: 5
+
+# Tell the driver Quke is using to send a different user-agent value to the site
+# under test. Useful if you want the underlying driver to spoof what kind of
+# browser the request is coming from. For example you may want to pretend to be
+# a mobile browser so you can check what you get back versus the desktop
+# version. Or you want to pretend to be another kind of browser, because the one
+# you have is not supported by the site.
+# user_agent: "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)"
+
+# Currently only supported when using the phantomjs driver (ignored by the
+# others). In phantomjs if a site has a javascript error we can configure it
+# to throw an error which will cause the test to fail. Quke by default sets this
+# to true, however you can override it by setting this flag to false.
+# For example you may be dealing with a legacy site and JavaScript errors
+# are out of your scope. You still want to test other aspects of the site
+# but not let these errors prevent you from using phantomjs.
+javascript_errors: false
+
+# Anything you place under the 'custom' node in the `.config.yml` file will be
+# available within your steps and page objects by calling
+# `Quke::Quke.config.custom`. So using the example below we could access its
+# values in the following ways
+#
+# Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
+# Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+#
+# As long as what you add is valid YAML (check with a tool like
+# http://www.yamllint.com/) Quke will be able to pick it up and make it
+# available in your tests.
+custom:
+  accounts:
+    DataAgent:
+      username: data_agent_user@example.gov.uk
+    AdminAgent:
+      username: admin_agent_user@example.gov.uk
+    SuperAgent:
+      username: super_agent_user@example.gov.uk
+    SystemUser:
+      username: system_user@example.gov.uk
+
+
+# Local setup    
+  urls:
+    front_office: "http://localhost:3000"
+    back_office: "http:/localhost:3001"
+
+
+# If you are running Quke behind a proxy you can configure the proxy details
+# here. You'll need either the hostname or IP of the proxy server (don't include
+# the http:// bit) and the port number (typically 8080). Currently proxy
+# settings will only be applied if you are using the PhantomJS, Chrome or
+# Firefox drivers.
+# proxy:
+#   host: '10.10.2.70'
+#   port: 8080
+  # In some cases you may also need to tell the browser (driver) not to use the
+  # proxy for local or specific connections. For this simply provide a comma
+  # separated list of addresses.
+  #
+  # IMPORTANT NOTE! phantomjs does not currently support this option. If you
+  # have to go via a proxy server for external connections, but not local ones
+  # you will be limited to using either the Chrome or Firefox drivers.
+  # no_proxy: '127.0.0.1,192.168.0.1'
+
+# If you select the browserstack driver, there are a number of options you
+# can pass through to setup your browserstack tests, username and auth_key
+# being the critical ones.
+# Please see https://www.browserstack.com/automate/capabilities for more details
+browserstack:
+  # To run your tests with browserstack you must provide a username and auth_key
+  # as a minimum.
+  # If you don't want to put these credentials in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variables BROWSERSTACK_USERNAME and BROWSERSTACK_AUTH_KEY
+  # username: 
+  # auth_key: 
+
+  # If you want to use local testing you must provide a key. You can find this
+  # in Browserstack once logged in under settings. Its typically the same value
+  # as the auth_key above.
+  # If you don't want to put this credential in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variable BROWSERSTACK_LOCAL_KEY
+  # local_key: 
+
+  # Anything set under capabilities will be passed directly by Quke to
+  # browserstack as means of configuring the test.
+  # So the config keys (e.g. build, project, name) you set should match a real
+  # browserstack capability, and the value exist in the range it expects. See
+  # for further reference on browserstack capabilities
+  # https://www.browserstack.com/automate/capabilities
+  # https://www.browserstack.com/automate/ruby#configure-capabilities
+  capabilities:
+    # Keep track of all your automated tests using the build and project
+    # capabilities. Group your tests into builds, and builds further into
+    # projects
+    project: 'Waste exemptions'
+    build: 'Start renewal'
+    # Allows you to specify an identifier for the test run.
+    # If you intend to repeat a test this might not be that applicable, but in
+    # the case of one off tests it might be useful
+    # name: 'Removing key person'
+
+    # To avoid invalid certificate errors while testing set acceptSslCerts to
+    # true. This is not listed on the general capabilities page but is here
+    # https://www.browserstack.com/automate/ruby#self-signed-certificates
+    acceptSslCerts: true
+    # Required if you want to generate screenshots at various steps in your test
+    # test. Browserstack default is false
+    browserstack.debug: false
+    # Required if you want to enable video recording during your test.
+    # Browserstack default is true
+    browserstack.video: true
+    # Required if you need to test a locally hosted (e.g. http://localhost:300)
+    # or private internal web site. Browserstack has a feature called local
+    # testing that Quke also supports, but to use
+    # - Browserstack must be your selected driver
+    # - You must have set local_key above
+    # - You must this value to true
+    browserstack.local: true
+    # Another setting not listed, setting the following will prevent any values
+    # you pass in, for example when filling in a form, from appearing in the
+    # logs. General use case is to prevent passwords being exposed, but beware
+    # that all input will be masked in the logs if set.
+    browserstack.maskSendKeys: true
+
+    # https://www.browserstack.com/automate/capabilities
+    browser: Chrome
+    os: 'Windows'
+    browser_version: '70.0'
+    os_version: '10'
+    # adding native events to help with clicking label instead of opaque radio button
+    nativeEvents: 'true'

--- a/.config_Firefox63_OSX.yml
+++ b/.config_Firefox63_OSX.yml
@@ -1,0 +1,166 @@
+# The standard place to add your features and step_definitions is in a folder
+# named 'features' at the root of the project. However if you'd like to name
+# this folder something else, you can tell Quke what the new name is here.
+# The default is features
+# features_folder: 'cukes'
+
+# Normally Capybara expects to be testing an in-process Rack application, but
+# we're using it to talk to a remote host. Users of Quke can set what this
+# will be by simply setting `app_host`. You can then use it directly using
+# Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
+# the full url each time
+app_host: 'http://localhost:3000'
+
+# Tells Quke which browser to use for testing. Choices are firefox, chrome
+# browserstack and phantomjs, with the default being phantomjs
+driver: browserstack
+
+# Add a pause (in seconds) between steps so you can visually track how the
+# browser is responding. Only useful if using a non-headless browser. The
+# default is 0
+pause: 0
+
+# Specify whether Quke should stop all tests once an error occurs. Useful in
+# Continuous Integration (CI) environments where a quick Yes/No is preferable to
+# a detailed response.
+stop_on_error: 2
+
+# Capybara will attempt to find an element for a period of time, rather than
+# immediately failing because the element cannot be found. This defaults to 2
+# seconds. However if the site you are working with is slow or features
+# elements that take some time to load you can increase this default.
+max_wait_time: 5
+
+# Tell the driver Quke is using to send a different user-agent value to the site
+# under test. Useful if you want the underlying driver to spoof what kind of
+# browser the request is coming from. For example you may want to pretend to be
+# a mobile browser so you can check what you get back versus the desktop
+# version. Or you want to pretend to be another kind of browser, because the one
+# you have is not supported by the site.
+# user_agent: "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)"
+
+# Currently only supported when using the phantomjs driver (ignored by the
+# others). In phantomjs if a site has a javascript error we can configure it
+# to throw an error which will cause the test to fail. Quke by default sets this
+# to true, however you can override it by setting this flag to false.
+# For example you may be dealing with a legacy site and JavaScript errors
+# are out of your scope. You still want to test other aspects of the site
+# but not let these errors prevent you from using phantomjs.
+javascript_errors: false
+
+# Anything you place under the 'custom' node in the `.config.yml` file will be
+# available within your steps and page objects by calling
+# `Quke::Quke.config.custom`. So using the example below we could access its
+# values in the following ways
+#
+# Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
+# Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+#
+# As long as what you add is valid YAML (check with a tool like
+# http://www.yamllint.com/) Quke will be able to pick it up and make it
+# available in your tests.
+custom:
+  accounts:
+    DataAgent:
+      username: data_agent_user@example.gov.uk
+    AdminAgent:
+      username: admin_agent_user@example.gov.uk
+    SuperAgent:
+      username: super_agent_user@example.gov.uk
+    SystemUser:
+      username: system_user@example.gov.uk
+
+
+# Local setup    
+  urls:
+    front_office: "http://localhost:3000"
+    back_office: "http:/localhost:3001"
+
+
+# If you are running Quke behind a proxy you can configure the proxy details
+# here. You'll need either the hostname or IP of the proxy server (don't include
+# the http:// bit) and the port number (typically 8080). Currently proxy
+# settings will only be applied if you are using the PhantomJS, Chrome or
+# Firefox drivers.
+# proxy:
+#   host: '10.10.2.70'
+#   port: 8080
+  # In some cases you may also need to tell the browser (driver) not to use the
+  # proxy for local or specific connections. For this simply provide a comma
+  # separated list of addresses.
+  #
+  # IMPORTANT NOTE! phantomjs does not currently support this option. If you
+  # have to go via a proxy server for external connections, but not local ones
+  # you will be limited to using either the Chrome or Firefox drivers.
+  # no_proxy: '127.0.0.1,192.168.0.1'
+
+# If you select the browserstack driver, there are a number of options you
+# can pass through to setup your browserstack tests, username and auth_key
+# being the critical ones.
+# Please see https://www.browserstack.com/automate/capabilities for more details
+browserstack:
+  # To run your tests with browserstack you must provide a username and auth_key
+  # as a minimum.
+  # If you don't want to put these credentials in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variables BROWSERSTACK_USERNAME and BROWSERSTACK_AUTH_KEY
+  # username: 
+  # auth_key: 
+
+  # If you want to use local testing you must provide a key. You can find this
+  # in Browserstack once logged in under settings. Its typically the same value
+  # as the auth_key above.
+  # If you don't want to put this credential in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variable BROWSERSTACK_LOCAL_KEY
+  # local_key: 
+
+  # Anything set under capabilities will be passed directly by Quke to
+  # browserstack as means of configuring the test.
+  # So the config keys (e.g. build, project, name) you set should match a real
+  # browserstack capability, and the value exist in the range it expects. See
+  # for further reference on browserstack capabilities
+  # https://www.browserstack.com/automate/capabilities
+  # https://www.browserstack.com/automate/ruby#configure-capabilities
+  capabilities:
+    # Keep track of all your automated tests using the build and project
+    # capabilities. Group your tests into builds, and builds further into
+    # projects
+    project: 'Waste exemptions'
+    build: 'Start renewal'
+    # Allows you to specify an identifier for the test run.
+    # If you intend to repeat a test this might not be that applicable, but in
+    # the case of one off tests it might be useful
+    # name: 'Removing key person'
+
+    # To avoid invalid certificate errors while testing set acceptSslCerts to
+    # true. This is not listed on the general capabilities page but is here
+    # https://www.browserstack.com/automate/ruby#self-signed-certificates
+    acceptSslCerts: true
+    # Required if you want to generate screenshots at various steps in your test
+    # test. Browserstack default is false
+    browserstack.debug: false
+    # Required if you want to enable video recording during your test.
+    # Browserstack default is true
+    browserstack.video: true
+    # Required if you need to test a locally hosted (e.g. http://localhost:300)
+    # or private internal web site. Browserstack has a feature called local
+    # testing that Quke also supports, but to use
+    # - Browserstack must be your selected driver
+    # - You must have set local_key above
+    # - You must this value to true
+    browserstack.local: true
+    # Another setting not listed, setting the following will prevent any values
+    # you pass in, for example when filling in a form, from appearing in the
+    # logs. General use case is to prevent passwords being exposed, but beware
+    # that all input will be masked in the logs if set.
+    browserstack.maskSendKeys: true
+
+    # https://www.browserstack.com/automate/capabilities
+    browser: Firefox
+    os: 'OS X'
+    browser_version: '63.0'
+    os_version: 'Mojave'
+    # adding native events to help with clicking label instead of opaque radio button
+    nativeEvents: 'true'

--- a/.config_Firefox63_W10.yml
+++ b/.config_Firefox63_W10.yml
@@ -1,0 +1,164 @@
+# The standard place to add your features and step_definitions is in a folder
+# named 'features' at the root of the project. However if you'd like to name
+# this folder something else, you can tell Quke what the new name is here.
+# The default is features
+# features_folder: 'cukes'
+
+# Normally Capybara expects to be testing an in-process Rack application, but
+# we're using it to talk to a remote host. Users of Quke can set what this
+# will be by simply setting `app_host`. You can then use it directly using
+# Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
+# the full url each time
+app_host: 'http://localhost:3000'
+
+# Tells Quke which browser to use for testing. Choices are firefox, chrome
+# browserstack and phantomjs, with the default being phantomjs
+driver: browserstack
+
+# Add a pause (in seconds) between steps so you can visually track how the
+# browser is responding. Only useful if using a non-headless browser. The
+# default is 0
+pause: 0
+
+# Specify whether Quke should stop all tests once an error occurs. Useful in
+# Continuous Integration (CI) environments where a quick Yes/No is preferable to
+# a detailed response.
+stop_on_error: 2
+
+# Capybara will attempt to find an element for a period of time, rather than
+# immediately failing because the element cannot be found. This defaults to 2
+# seconds. However if the site you are working with is slow or features
+# elements that take some time to load you can increase this default.
+max_wait_time: 5
+
+# Tell the driver Quke is using to send a different user-agent value to the site
+# under test. Useful if you want the underlying driver to spoof what kind of
+# browser the request is coming from. For example you may want to pretend to be
+# a mobile browser so you can check what you get back versus the desktop
+# version. Or you want to pretend to be another kind of browser, because the one
+# you have is not supported by the site.
+# user_agent: "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)"
+
+# Currently only supported when using the phantomjs driver (ignored by the
+# others). In phantomjs if a site has a javascript error we can configure it
+# to throw an error which will cause the test to fail. Quke by default sets this
+# to true, however you can override it by setting this flag to false.
+# For example you may be dealing with a legacy site and JavaScript errors
+# are out of your scope. You still want to test other aspects of the site
+# but not let these errors prevent you from using phantomjs.
+javascript_errors: false
+
+# Anything you place under the 'custom' node in the `.config.yml` file will be
+# available within your steps and page objects by calling
+# `Quke::Quke.config.custom`. So using the example below we could access its
+# values in the following ways
+#
+# Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
+# Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+#
+# As long as what you add is valid YAML (check with a tool like
+# http://www.yamllint.com/) Quke will be able to pick it up and make it
+# available in your tests.
+custom:
+  accounts:
+    DataAgent:
+      username: data_agent_user@example.gov.uk
+    AdminAgent:
+      username: admin_agent_user@example.gov.uk
+    SuperAgent:
+      username: super_agent_user@example.gov.uk
+    SystemUser:
+      username: system_user@example.gov.uk
+
+
+# Local setup    
+  urls:
+    front_office: "http://localhost:3000"
+    back_office: "http:/localhost:3001"
+
+
+# If you are running Quke behind a proxy you can configure the proxy details
+# here. You'll need either the hostname or IP of the proxy server (don't include
+# the http:// bit) and the port number (typically 8080). Currently proxy
+# settings will only be applied if you are using the PhantomJS, Chrome or
+# Firefox drivers.
+# proxy:
+#   host: '10.10.2.70'
+#   port: 8080
+  # In some cases you may also need to tell the browser (driver) not to use the
+  # proxy for local or specific connections. For this simply provide a comma
+  # separated list of addresses.
+  #
+  # IMPORTANT NOTE! phantomjs does not currently support this option. If you
+  # have to go via a proxy server for external connections, but not local ones
+  # you will be limited to using either the Chrome or Firefox drivers.
+  # no_proxy: '127.0.0.1,192.168.0.1'
+
+# If you select the browserstack driver, there are a number of options you
+# can pass through to setup your browserstack tests, username and auth_key
+# being the critical ones.
+# Please see https://www.browserstack.com/automate/capabilities for more details
+browserstack:
+  # To run your tests with browserstack you must provide a username and auth_key
+  # as a minimum.
+  # If you don't want to put these credentials in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variables BROWSERSTACK_USERNAME and BROWSERSTACK_AUTH_KEY
+  # username: 
+  # auth_key: 
+
+  # If you want to use local testing you must provide a key. You can find this
+  # in Browserstack once logged in under settings. Its typically the same value
+  # as the auth_key above.
+  # If you don't want to put this credential in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variable BROWSERSTACK_LOCAL_KEY
+  # local_key: 
+
+  # Anything set under capabilities will be passed directly by Quke to
+  # browserstack as means of configuring the test.
+  # So the config keys (e.g. build, project, name) you set should match a real
+  # browserstack capability, and the value exist in the range it expects. See
+  # for further reference on browserstack capabilities
+  # https://www.browserstack.com/automate/capabilities
+  # https://www.browserstack.com/automate/ruby#configure-capabilities
+  capabilities:
+    # Keep track of all your automated tests using the build and project
+    # capabilities. Group your tests into builds, and builds further into
+    # projects
+    project: 'Waste exemptions'
+    build: 'Start renewal'
+    # Allows you to specify an identifier for the test run.
+    # If you intend to repeat a test this might not be that applicable, but in
+    # the case of one off tests it might be useful
+    # name: 'Removing key person'
+
+    # To avoid invalid certificate errors while testing set acceptSslCerts to
+    # true. This is not listed on the general capabilities page but is here
+    # https://www.browserstack.com/automate/ruby#self-signed-certificates
+    acceptSslCerts: true
+    # Required if you want to generate screenshots at various steps in your test
+    # test. Browserstack default is false
+    browserstack.debug: false
+    # Required if you want to enable video recording during your test.
+    # Browserstack default is true
+    browserstack.video: true
+    # Required if you need to test a locally hosted (e.g. http://localhost:300)
+    # or private internal web site. Browserstack has a feature called local
+    # testing that Quke also supports, but to use
+    # - Browserstack must be your selected driver
+    # - You must have set local_key above
+    # - You must this value to true
+    browserstack.local: true
+    # Another setting not listed, setting the following will prevent any values
+    # you pass in, for example when filling in a form, from appearing in the
+    # logs. General use case is to prevent passwords being exposed, but beware
+    # that all input will be masked in the logs if set.
+    browserstack.maskSendKeys: true
+
+    # https://www.browserstack.com/automate/capabilities
+    browser: Firefox
+    os: 'Windows'
+    browser_version: '63.0'
+    os_version: '10'

--- a/.config_Galaxy_Note_8.yml
+++ b/.config_Galaxy_Note_8.yml
@@ -1,0 +1,164 @@
+# The standard place to add your features and step_definitions is in a folder
+# named 'features' at the root of the project. However if you'd like to name
+# this folder something else, you can tell Quke what the new name is here.
+# The default is features
+# features_folder: 'cukes'
+
+# Normally Capybara expects to be testing an in-process Rack application, but
+# we're using it to talk to a remote host. Users of Quke can set what this
+# will be by simply setting `app_host`. You can then use it directly using
+# Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
+# the full url each time
+app_host: 'http://localhost:3000'
+
+# Tells Quke which browser to use for testing. Choices are firefox, chrome
+# browserstack and phantomjs, with the default being phantomjs
+driver: browserstack
+
+# Add a pause (in seconds) between steps so you can visually track how the
+# browser is responding. Only useful if using a non-headless browser. The
+# default is 0
+pause: 0
+
+# Specify whether Quke should stop all tests once an error occurs. Useful in
+# Continuous Integration (CI) environments where a quick Yes/No is preferable to
+# a detailed response.
+stop_on_error: 2
+
+# Capybara will attempt to find an element for a period of time, rather than
+# immediately failing because the element cannot be found. This defaults to 2
+# seconds. However if the site you are working with is slow or features
+# elements that take some time to load you can increase this default.
+max_wait_time: 5
+
+# Tell the driver Quke is using to send a different user-agent value to the site
+# under test. Useful if you want the underlying driver to spoof what kind of
+# browser the request is coming from. For example you may want to pretend to be
+# a mobile browser so you can check what you get back versus the desktop
+# version. Or you want to pretend to be another kind of browser, because the one
+# you have is not supported by the site.
+# user_agent: "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)"
+
+# Currently only supported when using the phantomjs driver (ignored by the
+# others). In phantomjs if a site has a javascript error we can configure it
+# to throw an error which will cause the test to fail. Quke by default sets this
+# to true, however you can override it by setting this flag to false.
+# For example you may be dealing with a legacy site and JavaScript errors
+# are out of your scope. You still want to test other aspects of the site
+# but not let these errors prevent you from using phantomjs.
+javascript_errors: false
+
+# Anything you place under the 'custom' node in the `.config.yml` file will be
+# available within your steps and page objects by calling
+# `Quke::Quke.config.custom`. So using the example below we could access its
+# values in the following ways
+#
+# Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
+# Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+#
+# As long as what you add is valid YAML (check with a tool like
+# http://www.yamllint.com/) Quke will be able to pick it up and make it
+# available in your tests.
+custom:
+  accounts:
+    DataAgent:
+      username: data_agent_user@example.gov.uk
+    AdminAgent:
+      username: admin_agent_user@example.gov.uk
+    SuperAgent:
+      username: super_agent_user@example.gov.uk
+    SystemUser:
+      username: system_user@example.gov.uk
+
+
+# Local setup    
+  urls:
+    front_office: "http://localhost:3000"
+    back_office: "http:/localhost:3001"
+
+
+# If you are running Quke behind a proxy you can configure the proxy details
+# here. You'll need either the hostname or IP of the proxy server (don't include
+# the http:// bit) and the port number (typically 8080). Currently proxy
+# settings will only be applied if you are using the PhantomJS, Chrome or
+# Firefox drivers.
+# proxy:
+#   host: '10.10.2.70'
+#   port: 8080
+  # In some cases you may also need to tell the browser (driver) not to use the
+  # proxy for local or specific connections. For this simply provide a comma
+  # separated list of addresses.
+  #
+  # IMPORTANT NOTE! phantomjs does not currently support this option. If you
+  # have to go via a proxy server for external connections, but not local ones
+  # you will be limited to using either the Chrome or Firefox drivers.
+  # no_proxy: '127.0.0.1,192.168.0.1'
+
+# If you select the browserstack driver, there are a number of options you
+# can pass through to setup your browserstack tests, username and auth_key
+# being the critical ones.
+# Please see https://www.browserstack.com/automate/capabilities for more details
+browserstack:
+  # To run your tests with browserstack you must provide a username and auth_key
+  # as a minimum.
+  # If you don't want to put these credentials in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variables BROWSERSTACK_USERNAME and BROWSERSTACK_AUTH_KEY
+  # username: 
+  # auth_key: 
+
+  # If you want to use local testing you must provide a key. You can find this
+  # in Browserstack once logged in under settings. Its typically the same value
+  # as the auth_key above.
+  # If you don't want to put this credential in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variable BROWSERSTACK_LOCAL_KEY
+  # local_key: 
+
+  # Anything set under capabilities will be passed directly by Quke to
+  # browserstack as means of configuring the test.
+  # So the config keys (e.g. build, project, name) you set should match a real
+  # browserstack capability, and the value exist in the range it expects. See
+  # for further reference on browserstack capabilities
+  # https://www.browserstack.com/automate/capabilities
+  # https://www.browserstack.com/automate/ruby#configure-capabilities
+  capabilities:
+    # Keep track of all your automated tests using the build and project
+    # capabilities. Group your tests into builds, and builds further into
+    # projects
+    project: 'Waste exemptions'
+    build: 'Start renewal'
+    # Allows you to specify an identifier for the test run.
+    # If you intend to repeat a test this might not be that applicable, but in
+    # the case of one off tests it might be useful
+    # name: 'Removing key person'
+
+    # To avoid invalid certificate errors while testing set acceptSslCerts to
+    # true. This is not listed on the general capabilities page but is here
+    # https://www.browserstack.com/automate/ruby#self-signed-certificates
+    acceptSslCerts: true
+    # Required if you want to generate screenshots at various steps in your test
+    # test. Browserstack default is false
+    browserstack.debug: false
+    # Required if you want to enable video recording during your test.
+    # Browserstack default is true
+    browserstack.video: true
+    # Required if you need to test a locally hosted (e.g. http://localhost:300)
+    # or private internal web site. Browserstack has a feature called local
+    # testing that Quke also supports, but to use
+    # - Browserstack must be your selected driver
+    # - You must have set local_key above
+    # - You must this value to true
+    browserstack.local: true
+    # Another setting not listed, setting the following will prevent any values
+    # you pass in, for example when filling in a form, from appearing in the
+    # logs. General use case is to prevent passwords being exposed, but beware
+    # that all input will be masked in the logs if set.
+    browserstack.maskSendKeys: true
+
+    # https://www.browserstack.com/automate/capabilities
+    device: 'Samsung Galaxy Note 8'
+    real_mobile: 'true'
+    os_version: '7.1'
+    

--- a/.config_Google_Pixel.yml
+++ b/.config_Google_Pixel.yml
@@ -1,0 +1,164 @@
+# The standard place to add your features and step_definitions is in a folder
+# named 'features' at the root of the project. However if you'd like to name
+# this folder something else, you can tell Quke what the new name is here.
+# The default is features
+# features_folder: 'cukes'
+
+# Normally Capybara expects to be testing an in-process Rack application, but
+# we're using it to talk to a remote host. Users of Quke can set what this
+# will be by simply setting `app_host`. You can then use it directly using
+# Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
+# the full url each time
+app_host: 'http://localhost:3000'
+
+# Tells Quke which browser to use for testing. Choices are firefox, chrome
+# browserstack and phantomjs, with the default being phantomjs
+driver: browserstack
+
+# Add a pause (in seconds) between steps so you can visually track how the
+# browser is responding. Only useful if using a non-headless browser. The
+# default is 0
+pause: 0
+
+# Specify whether Quke should stop all tests once an error occurs. Useful in
+# Continuous Integration (CI) environments where a quick Yes/No is preferable to
+# a detailed response.
+stop_on_error: 2
+
+# Capybara will attempt to find an element for a period of time, rather than
+# immediately failing because the element cannot be found. This defaults to 2
+# seconds. However if the site you are working with is slow or features
+# elements that take some time to load you can increase this default.
+max_wait_time: 5
+
+# Tell the driver Quke is using to send a different user-agent value to the site
+# under test. Useful if you want the underlying driver to spoof what kind of
+# browser the request is coming from. For example you may want to pretend to be
+# a mobile browser so you can check what you get back versus the desktop
+# version. Or you want to pretend to be another kind of browser, because the one
+# you have is not supported by the site.
+# user_agent: "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)"
+
+# Currently only supported when using the phantomjs driver (ignored by the
+# others). In phantomjs if a site has a javascript error we can configure it
+# to throw an error which will cause the test to fail. Quke by default sets this
+# to true, however you can override it by setting this flag to false.
+# For example you may be dealing with a legacy site and JavaScript errors
+# are out of your scope. You still want to test other aspects of the site
+# but not let these errors prevent you from using phantomjs.
+javascript_errors: false
+
+# Anything you place under the 'custom' node in the `.config.yml` file will be
+# available within your steps and page objects by calling
+# `Quke::Quke.config.custom`. So using the example below we could access its
+# values in the following ways
+#
+# Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
+# Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+#
+# As long as what you add is valid YAML (check with a tool like
+# http://www.yamllint.com/) Quke will be able to pick it up and make it
+# available in your tests.
+custom:
+  accounts:
+    DataAgent:
+      username: data_agent_user@example.gov.uk
+    AdminAgent:
+      username: admin_agent_user@example.gov.uk
+    SuperAgent:
+      username: super_agent_user@example.gov.uk
+    SystemUser:
+      username: system_user@example.gov.uk
+
+
+# Local setup    
+  urls:
+    front_office: "http://localhost:3000"
+    back_office: "http:/localhost:3001"
+
+
+# If you are running Quke behind a proxy you can configure the proxy details
+# here. You'll need either the hostname or IP of the proxy server (don't include
+# the http:// bit) and the port number (typically 8080). Currently proxy
+# settings will only be applied if you are using the PhantomJS, Chrome or
+# Firefox drivers.
+# proxy:
+#   host: '10.10.2.70'
+#   port: 8080
+  # In some cases you may also need to tell the browser (driver) not to use the
+  # proxy for local or specific connections. For this simply provide a comma
+  # separated list of addresses.
+  #
+  # IMPORTANT NOTE! phantomjs does not currently support this option. If you
+  # have to go via a proxy server for external connections, but not local ones
+  # you will be limited to using either the Chrome or Firefox drivers.
+  # no_proxy: '127.0.0.1,192.168.0.1'
+
+# If you select the browserstack driver, there are a number of options you
+# can pass through to setup your browserstack tests, username and auth_key
+# being the critical ones.
+# Please see https://www.browserstack.com/automate/capabilities for more details
+browserstack:
+  # To run your tests with browserstack you must provide a username and auth_key
+  # as a minimum.
+  # If you don't want to put these credentials in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variables BROWSERSTACK_USERNAME and BROWSERSTACK_AUTH_KEY
+  # username: 
+  # auth_key: 
+
+  # If you want to use local testing you must provide a key. You can find this
+  # in Browserstack once logged in under settings. Its typically the same value
+  # as the auth_key above.
+  # If you don't want to put this credential in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variable BROWSERSTACK_LOCAL_KEY
+  # local_key: 
+
+  # Anything set under capabilities will be passed directly by Quke to
+  # browserstack as means of configuring the test.
+  # So the config keys (e.g. build, project, name) you set should match a real
+  # browserstack capability, and the value exist in the range it expects. See
+  # for further reference on browserstack capabilities
+  # https://www.browserstack.com/automate/capabilities
+  # https://www.browserstack.com/automate/ruby#configure-capabilities
+  capabilities:
+    # Keep track of all your automated tests using the build and project
+    # capabilities. Group your tests into builds, and builds further into
+    # projects
+    project: 'Waste exemptions'
+    build: 'Start renewal'
+    # Allows you to specify an identifier for the test run.
+    # If you intend to repeat a test this might not be that applicable, but in
+    # the case of one off tests it might be useful
+    # name: 'Removing key person'
+
+    # To avoid invalid certificate errors while testing set acceptSslCerts to
+    # true. This is not listed on the general capabilities page but is here
+    # https://www.browserstack.com/automate/ruby#self-signed-certificates
+    acceptSslCerts: true
+    # Required if you want to generate screenshots at various steps in your test
+    # test. Browserstack default is false
+    browserstack.debug: false
+    # Required if you want to enable video recording during your test.
+    # Browserstack default is true
+    browserstack.video: true
+    # Required if you need to test a locally hosted (e.g. http://localhost:300)
+    # or private internal web site. Browserstack has a feature called local
+    # testing that Quke also supports, but to use
+    # - Browserstack must be your selected driver
+    # - You must have set local_key above
+    # - You must this value to true
+    browserstack.local: true
+    # Another setting not listed, setting the following will prevent any values
+    # you pass in, for example when filling in a form, from appearing in the
+    # logs. General use case is to prevent passwords being exposed, but beware
+    # that all input will be masked in the logs if set.
+    browserstack.maskSendKeys: true
+
+    # https://www.browserstack.com/automate/capabilities
+    device: 'Google Pixel 2'
+    real_mobile: 'true'
+    os_version: '8.0'
+    

--- a/.config_Safari12_OSX.yml
+++ b/.config_Safari12_OSX.yml
@@ -1,0 +1,166 @@
+# The standard place to add your features and step_definitions is in a folder
+# named 'features' at the root of the project. However if you'd like to name
+# this folder something else, you can tell Quke what the new name is here.
+# The default is features
+# features_folder: 'cukes'
+
+# Normally Capybara expects to be testing an in-process Rack application, but
+# we're using it to talk to a remote host. Users of Quke can set what this
+# will be by simply setting `app_host`. You can then use it directly using
+# Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
+# the full url each time
+app_host: 'http://localhost:3000'
+
+# Tells Quke which browser to use for testing. Choices are firefox, chrome
+# browserstack and phantomjs, with the default being phantomjs
+driver: browserstack
+
+# Add a pause (in seconds) between steps so you can visually track how the
+# browser is responding. Only useful if using a non-headless browser. The
+# default is 0
+pause: 0
+
+# Specify whether Quke should stop all tests once an error occurs. Useful in
+# Continuous Integration (CI) environments where a quick Yes/No is preferable to
+# a detailed response.
+stop_on_error: 2
+
+# Capybara will attempt to find an element for a period of time, rather than
+# immediately failing because the element cannot be found. This defaults to 2
+# seconds. However if the site you are working with is slow or features
+# elements that take some time to load you can increase this default.
+max_wait_time: 5
+
+# Tell the driver Quke is using to send a different user-agent value to the site
+# under test. Useful if you want the underlying driver to spoof what kind of
+# browser the request is coming from. For example you may want to pretend to be
+# a mobile browser so you can check what you get back versus the desktop
+# version. Or you want to pretend to be another kind of browser, because the one
+# you have is not supported by the site.
+# user_agent: "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)"
+
+# Currently only supported when using the phantomjs driver (ignored by the
+# others). In phantomjs if a site has a javascript error we can configure it
+# to throw an error which will cause the test to fail. Quke by default sets this
+# to true, however you can override it by setting this flag to false.
+# For example you may be dealing with a legacy site and JavaScript errors
+# are out of your scope. You still want to test other aspects of the site
+# but not let these errors prevent you from using phantomjs.
+javascript_errors: false
+
+# Anything you place under the 'custom' node in the `.config.yml` file will be
+# available within your steps and page objects by calling
+# `Quke::Quke.config.custom`. So using the example below we could access its
+# values in the following ways
+#
+# Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
+# Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+#
+# As long as what you add is valid YAML (check with a tool like
+# http://www.yamllint.com/) Quke will be able to pick it up and make it
+# available in your tests.
+custom:
+  accounts:
+    DataAgent:
+      username: data_agent_user@example.gov.uk
+    AdminAgent:
+      username: admin_agent_user@example.gov.uk
+    SuperAgent:
+      username: super_agent_user@example.gov.uk
+    SystemUser:
+      username: system_user@example.gov.uk
+
+
+# Local setup    
+  urls:
+    front_office: "http://localhost:3000"
+    back_office: "http:/localhost:3001"
+
+
+# If you are running Quke behind a proxy you can configure the proxy details
+# here. You'll need either the hostname or IP of the proxy server (don't include
+# the http:// bit) and the port number (typically 8080). Currently proxy
+# settings will only be applied if you are using the PhantomJS, Chrome or
+# Firefox drivers.
+# proxy:
+#   host: '10.10.2.70'
+#   port: 8080
+  # In some cases you may also need to tell the browser (driver) not to use the
+  # proxy for local or specific connections. For this simply provide a comma
+  # separated list of addresses.
+  #
+  # IMPORTANT NOTE! phantomjs does not currently support this option. If you
+  # have to go via a proxy server for external connections, but not local ones
+  # you will be limited to using either the Chrome or Firefox drivers.
+  # no_proxy: '127.0.0.1,192.168.0.1'
+
+# If you select the browserstack driver, there are a number of options you
+# can pass through to setup your browserstack tests, username and auth_key
+# being the critical ones.
+# Please see https://www.browserstack.com/automate/capabilities for more details
+browserstack:
+  # To run your tests with browserstack you must provide a username and auth_key
+  # as a minimum.
+  # If you don't want to put these credentials in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variables BROWSERSTACK_USERNAME and BROWSERSTACK_AUTH_KEY
+  # username: 
+  # auth_key: 
+
+  # If you want to use local testing you must provide a key. You can find this
+  # in Browserstack once logged in under settings. Its typically the same value
+  # as the auth_key above.
+  # If you don't want to put this credential in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variable BROWSERSTACK_LOCAL_KEY
+  # local_key: 
+
+  # Anything set under capabilities will be passed directly by Quke to
+  # browserstack as means of configuring the test.
+  # So the config keys (e.g. build, project, name) you set should match a real
+  # browserstack capability, and the value exist in the range it expects. See
+  # for further reference on browserstack capabilities
+  # https://www.browserstack.com/automate/capabilities
+  # https://www.browserstack.com/automate/ruby#configure-capabilities
+  capabilities:
+    # Keep track of all your automated tests using the build and project
+    # capabilities. Group your tests into builds, and builds further into
+    # projects
+    project: 'Waste exemptions'
+    build: 'Start renewal'
+    # Allows you to specify an identifier for the test run.
+    # If you intend to repeat a test this might not be that applicable, but in
+    # the case of one off tests it might be useful
+    # name: 'Removing key person'
+
+    # To avoid invalid certificate errors while testing set acceptSslCerts to
+    # true. This is not listed on the general capabilities page but is here
+    # https://www.browserstack.com/automate/ruby#self-signed-certificates
+    acceptSslCerts: true
+    # Required if you want to generate screenshots at various steps in your test
+    # test. Browserstack default is false
+    browserstack.debug: false
+    # Required if you want to enable video recording during your test.
+    # Browserstack default is true
+    browserstack.video: true
+    # Required if you need to test a locally hosted (e.g. http://localhost:300)
+    # or private internal web site. Browserstack has a feature called local
+    # testing that Quke also supports, but to use
+    # - Browserstack must be your selected driver
+    # - You must have set local_key above
+    # - You must this value to true
+    browserstack.local: true
+    # Another setting not listed, setting the following will prevent any values
+    # you pass in, for example when filling in a form, from appearing in the
+    # logs. General use case is to prevent passwords being exposed, but beware
+    # that all input will be masked in the logs if set.
+    browserstack.maskSendKeys: true
+
+    # https://www.browserstack.com/automate/capabilities
+    browser: Safari
+    os: 'OS X'
+    browser_version: '12.0'
+    os_version: 'Mojave'
+    # adding native events to help with clicking label instead of opaque radio button
+    nativeEvents: 'true'

--- a/.config_edge16_W10.yml
+++ b/.config_edge16_W10.yml
@@ -1,0 +1,167 @@
+# The standard place to add your features and step_definitions is in a folder
+# named 'features' at the root of the project. However if you'd like to name
+# this folder something else, you can tell Quke what the new name is here.
+# The default is features
+# features_folder: 'cukes'
+
+# Normally Capybara expects to be testing an in-process Rack application, but
+# we're using it to talk to a remote host. Users of Quke can set what this
+# will be by simply setting `app_host`. You can then use it directly using
+# Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
+# the full url each time
+app_host: 'http://localhost:3000'
+
+# Tells Quke which browser to use for testing. Choices are firefox, chrome
+# browserstack and phantomjs, with the default being phantomjs
+driver: browserstack
+
+# Add a pause (in seconds) between steps so you can visually track how the
+# browser is responding. Only useful if using a non-headless browser. The
+# default is 0
+pause: 0
+
+# Specify whether Quke should stop all tests once an error occurs. Useful in
+# Continuous Integration (CI) environments where a quick Yes/No is preferable to
+# a detailed response.
+stop_on_error: 2
+
+# Capybara will attempt to find an element for a period of time, rather than
+# immediately failing because the element cannot be found. This defaults to 2
+# seconds. However if the site you are working with is slow or features
+# elements that take some time to load you can increase this default.
+max_wait_time: 5
+
+# Tell the driver Quke is using to send a different user-agent value to the site
+# under test. Useful if you want the underlying driver to spoof what kind of
+# browser the request is coming from. For example you may want to pretend to be
+# a mobile browser so you can check what you get back versus the desktop
+# version. Or you want to pretend to be another kind of browser, because the one
+# you have is not supported by the site.
+# user_agent: "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)"
+
+# Currently only supported when using the phantomjs driver (ignored by the
+# others). In phantomjs if a site has a javascript error we can configure it
+# to throw an error which will cause the test to fail. Quke by default sets this
+# to true, however you can override it by setting this flag to false.
+# For example you may be dealing with a legacy site and JavaScript errors
+# are out of your scope. You still want to test other aspects of the site
+# but not let these errors prevent you from using phantomjs.
+javascript_errors: false
+
+# Anything you place under the 'custom' node in the `.config.yml` file will be
+# available within your steps and page objects by calling
+# `Quke::Quke.config.custom`. So using the example below we could access its
+# values in the following ways
+#
+# Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
+# Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+#
+# As long as what you add is valid YAML (check with a tool like
+# http://www.yamllint.com/) Quke will be able to pick it up and make it
+# available in your tests.
+custom:
+  accounts:
+    DataAgent:
+      username: data_agent_user@example.gov.uk
+    AdminAgent:
+      username: admin_agent_user@example.gov.uk
+    SuperAgent:
+      username: super_agent_user@example.gov.uk
+    SystemUser:
+      username: system_user@example.gov.uk
+
+
+# Local setup    
+  urls:
+    front_office: "http://localhost:3000"
+    back_office: "http:/localhost:3001"
+
+
+# If you are running Quke behind a proxy you can configure the proxy details
+# here. You'll need either the hostname or IP of the proxy server (don't include
+# the http:// bit) and the port number (typically 8080). Currently proxy
+# settings will only be applied if you are using the PhantomJS, Chrome or
+# Firefox drivers.
+# proxy:
+#   host: '10.10.2.70'
+#   port: 8080
+  # In some cases you may also need to tell the browser (driver) not to use the
+  # proxy for local or specific connections. For this simply provide a comma
+  # separated list of addresses.
+  #
+  # IMPORTANT NOTE! phantomjs does not currently support this option. If you
+  # have to go via a proxy server for external connections, but not local ones
+  # you will be limited to using either the Chrome or Firefox drivers.
+  # no_proxy: '127.0.0.1,192.168.0.1'
+
+# If you select the browserstack driver, there are a number of options you
+# can pass through to setup your browserstack tests, username and auth_key
+# being the critical ones.
+# Please see https://www.browserstack.com/automate/capabilities for more details
+browserstack:
+  # To run your tests with browserstack you must provide a username and auth_key
+  # as a minimum.
+  # If you don't want to put these credentials in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variables BROWSERSTACK_USERNAME and BROWSERSTACK_AUTH_KEY
+  # username: 
+  # auth_key: 
+
+  # If you want to use local testing you must provide a key. You can find this
+  # in Browserstack once logged in under settings. Its typically the same value
+  # as the auth_key above.
+  # If you don't want to put this credential in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variable BROWSERSTACK_LOCAL_KEY
+  # local_key: 
+
+  # Anything set under capabilities will be passed directly by Quke to
+  # browserstack as means of configuring the test.
+  # So the config keys (e.g. build, project, name) you set should match a real
+  # browserstack capability, and the value exist in the range it expects. See
+  # for further reference on browserstack capabilities
+  # https://www.browserstack.com/automate/capabilities
+  # https://www.browserstack.com/automate/ruby#configure-capabilities
+  capabilities:
+    # Keep track of all your automated tests using the build and project
+    # capabilities. Group your tests into builds, and builds further into
+    # projects
+    project: 'Waste exemptions'
+    build: 'Start renewal'
+    # Allows you to specify an identifier for the test run.
+    # If you intend to repeat a test this might not be that applicable, but in
+    # the case of one off tests it might be useful
+    # name: 'Removing key person'
+
+    # To avoid invalid certificate errors while testing set acceptSslCerts to
+    # true. This is not listed on the general capabilities page but is here
+    # https://www.browserstack.com/automate/ruby#self-signed-certificates
+    acceptSslCerts: true
+    # Required if you want to generate screenshots at various steps in your test
+    # test. Browserstack default is false
+    browserstack.debug: false
+    # Required if you want to enable video recording during your test.
+    # Browserstack default is true
+    browserstack.video: true
+    # Required if you need to test a locally hosted (e.g. http://localhost:300)
+    # or private internal web site. Browserstack has a feature called local
+    # testing that Quke also supports, but to use
+    # - Browserstack must be your selected driver
+    # - You must have set local_key above
+    # - You must this value to true
+    browserstack.local: true
+    # Another setting not listed, setting the following will prevent any values
+    # you pass in, for example when filling in a form, from appearing in the
+    # logs. General use case is to prevent passwords being exposed, but beware
+    # that all input will be masked in the logs if set.
+    browserstack.maskSendKeys: true
+
+    # https://www.browserstack.com/automate/capabilities
+    browser: Edge
+    os: 'Windows'
+    # device: 'iPhone X'
+    # realMobile: 'true'
+    browser_version: '16.0'
+    os_version: '10'
+    javascriptEnabled: 'true'

--- a/.config_iPhone_8.yml
+++ b/.config_iPhone_8.yml
@@ -1,0 +1,164 @@
+# The standard place to add your features and step_definitions is in a folder
+# named 'features' at the root of the project. However if you'd like to name
+# this folder something else, you can tell Quke what the new name is here.
+# The default is features
+# features_folder: 'cukes'
+
+# Normally Capybara expects to be testing an in-process Rack application, but
+# we're using it to talk to a remote host. Users of Quke can set what this
+# will be by simply setting `app_host`. You can then use it directly using
+# Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
+# the full url each time
+app_host: 'http://localhost:3000'
+
+# Tells Quke which browser to use for testing. Choices are firefox, chrome
+# browserstack and phantomjs, with the default being phantomjs
+driver: browserstack
+
+# Add a pause (in seconds) between steps so you can visually track how the
+# browser is responding. Only useful if using a non-headless browser. The
+# default is 0
+pause: 0
+
+# Specify whether Quke should stop all tests once an error occurs. Useful in
+# Continuous Integration (CI) environments where a quick Yes/No is preferable to
+# a detailed response.
+stop_on_error: 2
+
+# Capybara will attempt to find an element for a period of time, rather than
+# immediately failing because the element cannot be found. This defaults to 2
+# seconds. However if the site you are working with is slow or features
+# elements that take some time to load you can increase this default.
+max_wait_time: 5
+
+# Tell the driver Quke is using to send a different user-agent value to the site
+# under test. Useful if you want the underlying driver to spoof what kind of
+# browser the request is coming from. For example you may want to pretend to be
+# a mobile browser so you can check what you get back versus the desktop
+# version. Or you want to pretend to be another kind of browser, because the one
+# you have is not supported by the site.
+# user_agent: "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)"
+
+# Currently only supported when using the phantomjs driver (ignored by the
+# others). In phantomjs if a site has a javascript error we can configure it
+# to throw an error which will cause the test to fail. Quke by default sets this
+# to true, however you can override it by setting this flag to false.
+# For example you may be dealing with a legacy site and JavaScript errors
+# are out of your scope. You still want to test other aspects of the site
+# but not let these errors prevent you from using phantomjs.
+javascript_errors: false
+
+# Anything you place under the 'custom' node in the `.config.yml` file will be
+# available within your steps and page objects by calling
+# `Quke::Quke.config.custom`. So using the example below we could access its
+# values in the following ways
+#
+# Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
+# Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+#
+# As long as what you add is valid YAML (check with a tool like
+# http://www.yamllint.com/) Quke will be able to pick it up and make it
+# available in your tests.
+custom:
+  accounts:
+    DataAgent:
+      username: data_agent_user@example.gov.uk
+    AdminAgent:
+      username: admin_agent_user@example.gov.uk
+    SuperAgent:
+      username: super_agent_user@example.gov.uk
+    SystemUser:
+      username: system_user@example.gov.uk
+
+
+# Local setup    
+  urls:
+    front_office: "http://localhost:3000"
+    back_office: "http:/localhost:3001"
+
+
+# If you are running Quke behind a proxy you can configure the proxy details
+# here. You'll need either the hostname or IP of the proxy server (don't include
+# the http:// bit) and the port number (typically 8080). Currently proxy
+# settings will only be applied if you are using the PhantomJS, Chrome or
+# Firefox drivers.
+# proxy:
+#   host: '10.10.2.70'
+#   port: 8080
+  # In some cases you may also need to tell the browser (driver) not to use the
+  # proxy for local or specific connections. For this simply provide a comma
+  # separated list of addresses.
+  #
+  # IMPORTANT NOTE! phantomjs does not currently support this option. If you
+  # have to go via a proxy server for external connections, but not local ones
+  # you will be limited to using either the Chrome or Firefox drivers.
+  # no_proxy: '127.0.0.1,192.168.0.1'
+
+# If you select the browserstack driver, there are a number of options you
+# can pass through to setup your browserstack tests, username and auth_key
+# being the critical ones.
+# Please see https://www.browserstack.com/automate/capabilities for more details
+browserstack:
+  # To run your tests with browserstack you must provide a username and auth_key
+  # as a minimum.
+  # If you don't want to put these credentials in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variables BROWSERSTACK_USERNAME and BROWSERSTACK_AUTH_KEY
+  # username: 
+  # auth_key: 
+
+  # If you want to use local testing you must provide a key. You can find this
+  # in Browserstack once logged in under settings. Its typically the same value
+  # as the auth_key above.
+  # If you don't want to put this credential in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variable BROWSERSTACK_LOCAL_KEY
+  # local_key: 
+
+  # Anything set under capabilities will be passed directly by Quke to
+  # browserstack as means of configuring the test.
+  # So the config keys (e.g. build, project, name) you set should match a real
+  # browserstack capability, and the value exist in the range it expects. See
+  # for further reference on browserstack capabilities
+  # https://www.browserstack.com/automate/capabilities
+  # https://www.browserstack.com/automate/ruby#configure-capabilities
+  capabilities:
+    # Keep track of all your automated tests using the build and project
+    # capabilities. Group your tests into builds, and builds further into
+    # projects
+    project: 'Waste exemptions'
+    build: 'Start renewal'
+    # Allows you to specify an identifier for the test run.
+    # If you intend to repeat a test this might not be that applicable, but in
+    # the case of one off tests it might be useful
+    # name: 'Removing key person'
+
+    # To avoid invalid certificate errors while testing set acceptSslCerts to
+    # true. This is not listed on the general capabilities page but is here
+    # https://www.browserstack.com/automate/ruby#self-signed-certificates
+    acceptSslCerts: true
+    # Required if you want to generate screenshots at various steps in your test
+    # test. Browserstack default is false
+    browserstack.debug: false
+    # Required if you want to enable video recording during your test.
+    # Browserstack default is true
+    browserstack.video: true
+    # Required if you need to test a locally hosted (e.g. http://localhost:300)
+    # or private internal web site. Browserstack has a feature called local
+    # testing that Quke also supports, but to use
+    # - Browserstack must be your selected driver
+    # - You must have set local_key above
+    # - You must this value to true
+    browserstack.local: true
+    # Another setting not listed, setting the following will prevent any values
+    # you pass in, for example when filling in a form, from appearing in the
+    # logs. General use case is to prevent passwords being exposed, but beware
+    # that all input will be masked in the logs if set.
+    browserstack.maskSendKeys: true
+
+    # https://www.browserstack.com/automate/capabilities
+    device: 'iPhone 8 Plus'
+    real_mobile: 'true'
+    os_version: '11.0'
+    

--- a/.config_iPhone_XS.yml
+++ b/.config_iPhone_XS.yml
@@ -1,0 +1,164 @@
+# The standard place to add your features and step_definitions is in a folder
+# named 'features' at the root of the project. However if you'd like to name
+# this folder something else, you can tell Quke what the new name is here.
+# The default is features
+# features_folder: 'cukes'
+
+# Normally Capybara expects to be testing an in-process Rack application, but
+# we're using it to talk to a remote host. Users of Quke can set what this
+# will be by simply setting `app_host`. You can then use it directly using
+# Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
+# the full url each time
+app_host: 'http://localhost:3000'
+
+# Tells Quke which browser to use for testing. Choices are firefox, chrome
+# browserstack and phantomjs, with the default being phantomjs
+driver: browserstack
+
+# Add a pause (in seconds) between steps so you can visually track how the
+# browser is responding. Only useful if using a non-headless browser. The
+# default is 0
+pause: 0
+
+# Specify whether Quke should stop all tests once an error occurs. Useful in
+# Continuous Integration (CI) environments where a quick Yes/No is preferable to
+# a detailed response.
+stop_on_error: 2
+
+# Capybara will attempt to find an element for a period of time, rather than
+# immediately failing because the element cannot be found. This defaults to 2
+# seconds. However if the site you are working with is slow or features
+# elements that take some time to load you can increase this default.
+max_wait_time: 5
+
+# Tell the driver Quke is using to send a different user-agent value to the site
+# under test. Useful if you want the underlying driver to spoof what kind of
+# browser the request is coming from. For example you may want to pretend to be
+# a mobile browser so you can check what you get back versus the desktop
+# version. Or you want to pretend to be another kind of browser, because the one
+# you have is not supported by the site.
+# user_agent: "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)"
+
+# Currently only supported when using the phantomjs driver (ignored by the
+# others). In phantomjs if a site has a javascript error we can configure it
+# to throw an error which will cause the test to fail. Quke by default sets this
+# to true, however you can override it by setting this flag to false.
+# For example you may be dealing with a legacy site and JavaScript errors
+# are out of your scope. You still want to test other aspects of the site
+# but not let these errors prevent you from using phantomjs.
+javascript_errors: false
+
+# Anything you place under the 'custom' node in the `.config.yml` file will be
+# available within your steps and page objects by calling
+# `Quke::Quke.config.custom`. So using the example below we could access its
+# values in the following ways
+#
+# Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
+# Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+#
+# As long as what you add is valid YAML (check with a tool like
+# http://www.yamllint.com/) Quke will be able to pick it up and make it
+# available in your tests.
+custom:
+  accounts:
+    DataAgent:
+      username: data_agent_user@example.gov.uk
+    AdminAgent:
+      username: admin_agent_user@example.gov.uk
+    SuperAgent:
+      username: super_agent_user@example.gov.uk
+    SystemUser:
+      username: system_user@example.gov.uk
+
+
+# Local setup    
+  urls:
+    front_office: "http://localhost:3000"
+    back_office: "http:/localhost:3001"
+
+
+# If you are running Quke behind a proxy you can configure the proxy details
+# here. You'll need either the hostname or IP of the proxy server (don't include
+# the http:// bit) and the port number (typically 8080). Currently proxy
+# settings will only be applied if you are using the PhantomJS, Chrome or
+# Firefox drivers.
+# proxy:
+#   host: '10.10.2.70'
+#   port: 8080
+  # In some cases you may also need to tell the browser (driver) not to use the
+  # proxy for local or specific connections. For this simply provide a comma
+  # separated list of addresses.
+  #
+  # IMPORTANT NOTE! phantomjs does not currently support this option. If you
+  # have to go via a proxy server for external connections, but not local ones
+  # you will be limited to using either the Chrome or Firefox drivers.
+  # no_proxy: '127.0.0.1,192.168.0.1'
+
+# If you select the browserstack driver, there are a number of options you
+# can pass through to setup your browserstack tests, username and auth_key
+# being the critical ones.
+# Please see https://www.browserstack.com/automate/capabilities for more details
+browserstack:
+  # To run your tests with browserstack you must provide a username and auth_key
+  # as a minimum.
+  # If you don't want to put these credentials in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variables BROWSERSTACK_USERNAME and BROWSERSTACK_AUTH_KEY
+  # username: 
+  # auth_key: 
+
+  # If you want to use local testing you must provide a key. You can find this
+  # in Browserstack once logged in under settings. Its typically the same value
+  # as the auth_key above.
+  # If you don't want to put this credential in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variable BROWSERSTACK_LOCAL_KEY
+  # local_key: 
+
+  # Anything set under capabilities will be passed directly by Quke to
+  # browserstack as means of configuring the test.
+  # So the config keys (e.g. build, project, name) you set should match a real
+  # browserstack capability, and the value exist in the range it expects. See
+  # for further reference on browserstack capabilities
+  # https://www.browserstack.com/automate/capabilities
+  # https://www.browserstack.com/automate/ruby#configure-capabilities
+  capabilities:
+    # Keep track of all your automated tests using the build and project
+    # capabilities. Group your tests into builds, and builds further into
+    # projects
+    project: 'Waste exemptions'
+    build: 'Start renewal'
+    # Allows you to specify an identifier for the test run.
+    # If you intend to repeat a test this might not be that applicable, but in
+    # the case of one off tests it might be useful
+    # name: 'Removing key person'
+
+    # To avoid invalid certificate errors while testing set acceptSslCerts to
+    # true. This is not listed on the general capabilities page but is here
+    # https://www.browserstack.com/automate/ruby#self-signed-certificates
+    acceptSslCerts: true
+    # Required if you want to generate screenshots at various steps in your test
+    # test. Browserstack default is false
+    browserstack.debug: false
+    # Required if you want to enable video recording during your test.
+    # Browserstack default is true
+    browserstack.video: true
+    # Required if you need to test a locally hosted (e.g. http://localhost:300)
+    # or private internal web site. Browserstack has a feature called local
+    # testing that Quke also supports, but to use
+    # - Browserstack must be your selected driver
+    # - You must have set local_key above
+    # - You must this value to true
+    browserstack.local: true
+    # Another setting not listed, setting the following will prevent any values
+    # you pass in, for example when filling in a form, from appearing in the
+    # logs. General use case is to prevent passwords being exposed, but beware
+    # that all input will be masked in the logs if set.
+    browserstack.maskSendKeys: true
+
+    # https://www.browserstack.com/automate/capabilities
+    device: 'iPhone XS'
+    real_mobile: 'true'
+    os_version: '12.0'
+    

--- a/.config_ie11_W10.yml
+++ b/.config_ie11_W10.yml
@@ -1,0 +1,166 @@
+# The standard place to add your features and step_definitions is in a folder
+# named 'features' at the root of the project. However if you'd like to name
+# this folder something else, you can tell Quke what the new name is here.
+# The default is features
+# features_folder: 'cukes'
+
+# Normally Capybara expects to be testing an in-process Rack application, but
+# we're using it to talk to a remote host. Users of Quke can set what this
+# will be by simply setting `app_host`. You can then use it directly using
+# Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
+# the full url each time
+app_host: 'http://localhost:3000'
+
+# Tells Quke which browser to use for testing. Choices are firefox, chrome
+# browserstack and phantomjs, with the default being phantomjs
+driver: browserstack
+
+# Add a pause (in seconds) between steps so you can visually track how the
+# browser is responding. Only useful if using a non-headless browser. The
+# default is 0
+pause: 0
+
+# Specify whether Quke should stop all tests once an error occurs. Useful in
+# Continuous Integration (CI) environments where a quick Yes/No is preferable to
+# a detailed response.
+stop_on_error: 2
+
+# Capybara will attempt to find an element for a period of time, rather than
+# immediately failing because the element cannot be found. This defaults to 2
+# seconds. However if the site you are working with is slow or features
+# elements that take some time to load you can increase this default.
+max_wait_time: 5
+
+# Tell the driver Quke is using to send a different user-agent value to the site
+# under test. Useful if you want the underlying driver to spoof what kind of
+# browser the request is coming from. For example you may want to pretend to be
+# a mobile browser so you can check what you get back versus the desktop
+# version. Or you want to pretend to be another kind of browser, because the one
+# you have is not supported by the site.
+# user_agent: "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)"
+
+# Currently only supported when using the phantomjs driver (ignored by the
+# others). In phantomjs if a site has a javascript error we can configure it
+# to throw an error which will cause the test to fail. Quke by default sets this
+# to true, however you can override it by setting this flag to false.
+# For example you may be dealing with a legacy site and JavaScript errors
+# are out of your scope. You still want to test other aspects of the site
+# but not let these errors prevent you from using phantomjs.
+javascript_errors: false
+
+# Anything you place under the 'custom' node in the `.config.yml` file will be
+# available within your steps and page objects by calling
+# `Quke::Quke.config.custom`. So using the example below we could access its
+# values in the following ways
+#
+# Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
+# Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+#
+# As long as what you add is valid YAML (check with a tool like
+# http://www.yamllint.com/) Quke will be able to pick it up and make it
+# available in your tests.
+custom:
+  accounts:
+    DataAgent:
+      username: data_agent_user@example.gov.uk
+    AdminAgent:
+      username: admin_agent_user@example.gov.uk
+    SuperAgent:
+      username: super_agent_user@example.gov.uk
+    SystemUser:
+      username: system_user@example.gov.uk
+
+
+# Local setup    
+  urls:
+    front_office: "http://localhost:3000"
+    back_office: "http:/localhost:3001"
+
+
+# If you are running Quke behind a proxy you can configure the proxy details
+# here. You'll need either the hostname or IP of the proxy server (don't include
+# the http:// bit) and the port number (typically 8080). Currently proxy
+# settings will only be applied if you are using the PhantomJS, Chrome or
+# Firefox drivers.
+# proxy:
+#   host: '10.10.2.70'
+#   port: 8080
+  # In some cases you may also need to tell the browser (driver) not to use the
+  # proxy for local or specific connections. For this simply provide a comma
+  # separated list of addresses.
+  #
+  # IMPORTANT NOTE! phantomjs does not currently support this option. If you
+  # have to go via a proxy server for external connections, but not local ones
+  # you will be limited to using either the Chrome or Firefox drivers.
+  # no_proxy: '127.0.0.1,192.168.0.1'
+
+# If you select the browserstack driver, there are a number of options you
+# can pass through to setup your browserstack tests, username and auth_key
+# being the critical ones.
+# Please see https://www.browserstack.com/automate/capabilities for more details
+browserstack:
+  # To run your tests with browserstack you must provide a username and auth_key
+  # as a minimum.
+  # If you don't want to put these credentials in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variables BROWSERSTACK_USERNAME and BROWSERSTACK_AUTH_KEY
+  # username: 
+  # auth_key: 
+
+  # If you want to use local testing you must provide a key. You can find this
+  # in Browserstack once logged in under settings. Its typically the same value
+  # as the auth_key above.
+  # If you don't want to put this credential in the config file (because you
+  # want to commit it to source control), Quke will also check for the existance
+  # of the environment variable BROWSERSTACK_LOCAL_KEY
+  # local_key: 
+
+  # Anything set under capabilities will be passed directly by Quke to
+  # browserstack as means of configuring the test.
+  # So the config keys (e.g. build, project, name) you set should match a real
+  # browserstack capability, and the value exist in the range it expects. See
+  # for further reference on browserstack capabilities
+  # https://www.browserstack.com/automate/capabilities
+  # https://www.browserstack.com/automate/ruby#configure-capabilities
+  capabilities:
+    # Keep track of all your automated tests using the build and project
+    # capabilities. Group your tests into builds, and builds further into
+    # projects
+    project: 'Waste exemptions'
+    build: 'Start renewal'
+    # Allows you to specify an identifier for the test run.
+    # If you intend to repeat a test this might not be that applicable, but in
+    # the case of one off tests it might be useful
+    # name: 'Removing key person'
+
+    # To avoid invalid certificate errors while testing set acceptSslCerts to
+    # true. This is not listed on the general capabilities page but is here
+    # https://www.browserstack.com/automate/ruby#self-signed-certificates
+    acceptSslCerts: true
+    # Required if you want to generate screenshots at various steps in your test
+    # test. Browserstack default is false
+    browserstack.debug: false
+    # Required if you want to enable video recording during your test.
+    # Browserstack default is true
+    browserstack.video: true
+    # Required if you need to test a locally hosted (e.g. http://localhost:300)
+    # or private internal web site. Browserstack has a feature called local
+    # testing that Quke also supports, but to use
+    # - Browserstack must be your selected driver
+    # - You must have set local_key above
+    # - You must this value to true
+    browserstack.local: true
+    # Another setting not listed, setting the following will prevent any values
+    # you pass in, for example when filling in a form, from appearing in the
+    # logs. General use case is to prevent passwords being exposed, but beware
+    # that all input will be masked in the logs if set.
+    browserstack.maskSendKeys: true
+
+    # https://www.browserstack.com/automate/capabilities
+    browser: IE
+    os: 'Windows'
+    browser_version: '11.0'
+    os_version: '10'
+    # adding native events to help with clicking label instead of opaque radio button
+    nativeEvents: 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ output.html
 
 # Ignore your project specific .config.yml config files
 *.config.yml
+
+bowerstack_local_log.txt

--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ end
 desc "Runs the tests used by continuous integration to check the project"
 task :ci do
   Rake::Task["rubocop"].invoke
-  sh %( bundle exec quke --tags @ci )
+  sh %( QUKE_CONFIG=.config-ci.yml bundle exec quke --tags @ci )
 end
 desc "Run all browserstack tests"
 task browserstack: %i[ie11_W10 Chrome70_W10 Safari12_OSX Chrome70_OSX Firefox63_OSX iPhone_8 Google_Pixel]

--- a/Rakefile
+++ b/Rakefile
@@ -24,3 +24,67 @@ task :ci do
   Rake::Task["rubocop"].invoke
   sh %( bundle exec quke --tags @ci )
 end
+desc "Run all browserstack tests"
+task browserstack: %i[ie11_W10 Chrome70_W10 Safari12_OSX Chrome70_OSX Firefox63_OSX iPhone_8 Google_Pixel]
+# Taking out due to JS bug Edge16_W10 Edge17_W10 Firefox63_W10  https://github.com/SeleniumHQ/selenium/issues/4651
+# Tasking out due to local Safari OS X12 issue https://www.browserstack.com/question/664
+
+desc "Run Internet explorer 11.0 Windows 10 test"
+task :ie11_W10 do
+  sh %( QUKE_CONFIG=.config_ie11_W10.yml bundle exec quke --tags @wip)
+end
+
+desc "Run Edge 16 Windows 10 test"
+task :Edge16_W10  do
+  sh %( QUKE_CONFIG=.config_Edge16_W10.yml bundle exec quke --tags @wip)
+end
+
+desc "Run Edge 17 Windows 10 test"
+task :Edge17_W10 do
+  sh %( QUKE_CONFIG=.config_Edge17_W10.yml bundle exec quke --tags @wip)
+end
+
+desc "Run Chrome 70 Windows 10 test"
+task :Chrome70_W10 do
+  sh %( QUKE_CONFIG=.config_Chrome70_W10.yml bundle exec quke --tags @wip)
+end
+
+desc "Run Firefox 63 W10 test"
+task :Firefox63_W10  do
+  sh %( QUKE_CONFIG=.config_Firefox63_W10.yml bundle exec quke --tags @wip)
+end
+
+desc "Run Safari 12 OS X Mojave test"
+task :Safari12_OSX  do
+  sh %( QUKE_CONFIG=.config_Safari12_OSX.yml bundle exec quke --tags @wip)
+end
+
+desc "Run Chrome 70 OS X Mojave test"
+task :Chrome70_OSX  do
+  sh %( QUKE_CONFIG=.config_Chrome70_OSX.yml bundle exec quke --tags @wip)
+end
+
+desc "Run Firefox 63 OS X Mojave test"
+task :Firefox63_OSX  do
+  sh %( QUKE_CONFIG=.config_Firefox63_OSX.yml bundle exec quke --tags @wip)
+end
+
+desc "Run iPhone XS test"
+task :iPhone_XS do
+  sh %( QUKE_CONFIG=.config_iPhone_XS.yml bundle exec quke --tags @wip)
+end
+
+desc "Run iPhone 8 plus test"
+task :iPhone_8 do
+  sh %( QUKE_CONFIG=.config_iPhone_8.yml bundle exec quke --tags @wip)
+end
+
+desc "Run Samsung Galaxy Note 8 test"
+task :Galaxy_Note_8 do
+  sh %( QUKE_CONFIG=.config_Galaxy_Note_8.yml bundle exec quke --tags @wip)
+end
+
+desc "Run Google Pixel 2 test"
+task :Google_Pixel do
+  sh %( QUKE_CONFIG=.config_Google_Pixel.yml bundle exec quke --tags @wip)
+end

--- a/features/back_office/back_office_registration.feature
+++ b/features/back_office/back_office_registration.feature
@@ -5,8 +5,8 @@ Feature: Back office user registers a customers new waste exemption activity
   So that I can register exemptions for customers over the phone
 
   Background:
-    Given I am an internal user
-      And I have a valid username and password
+    Given I sign in as a super user
+      
 
   @happy_path
   Scenario: Registration by a NCCC user

--- a/features/back_office/backoffice_site_address.feature
+++ b/features/back_office/backoffice_site_address.feature
@@ -5,8 +5,8 @@ Feature: National grid reference and site area details are found from site postc
   So that I can check the activity location for exemption restrictions
 
   Background:
-    Given I am an internal user
-      And I have a valid username and password
+    Given I sign in as a super user
+      
 
   @happy_path
   Scenario Outline: Registration by a NCCC user using a postcode for site address - NGR and area is added to registration

--- a/features/back_office/confirmation_letters_export.feature
+++ b/features/back_office/confirmation_letters_export.feature
@@ -5,8 +5,8 @@ Feature: Back office users can create confirmation letter exports
   So that I send all assisted digital registrations proof of their registration
 
   Background:
-    Given I am an internal user
-      And I have a valid username and password
+    Given I sign in as a super user
+      
 
   Scenario: Back office user exports confirmation letters
      When I export confirmation letters for today

--- a/features/back_office/deregister_exemption.feature
+++ b/features/back_office/deregister_exemption.feature
@@ -6,8 +6,8 @@ Feature: Back office users can 'deregister' individual exemptions
   Or the business needs to revoke it
 
   Background:
-    Given I am an internal user
-      And I have a valid username and password
+    Given I sign in as a super user
+      
 
   @happy_path
   Scenario: Revoking one exemption on a registration with multiple exemptions

--- a/features/back_office/deregister_registration.feature
+++ b/features/back_office/deregister_registration.feature
@@ -6,8 +6,8 @@ Feature: Back office users can 'deregister' the whole registration
   Or the business needs to revoke it
 
   Background:
-    Given I am an internal user
-      And I have a valid username and password
+    Given I sign in as a super user
+      
 
   @happy_path
   Scenario: Revoking a registration with multiple exemptions

--- a/features/back_office/registrations_export.feature
+++ b/features/back_office/registrations_export.feature
@@ -5,8 +5,8 @@ Feature: Back office users can export registrations
   So that I can report on registration numbers and exemption types
 
   Background:
-    Given I am an internal user
-      And I have a valid username and password
+    Given I sign in as a system user
+      
 
   @happy_path
   Scenario: Back office user exporting registrations

--- a/features/front_office/register_new_exemption.feature
+++ b/features/front_office/register_new_exemption.feature
@@ -7,7 +7,7 @@ Feature: Individual registers a waste exemption
   Background:
     Given start a new waste exemption registraton
 
-  @happy_path @wip
+  @happy_path
   Scenario: Registration by an individual
     Given I am an individual
      When I register an exemption

--- a/features/front_office/register_new_exemption.feature
+++ b/features/front_office/register_new_exemption.feature
@@ -5,10 +5,9 @@ Feature: Individual registers a waste exemption
   So that know that I am complying with regulations
 
   Background:
-    Given I am an external user
-      And I select a new exemption
+    Given start a new waste exemption registraton
 
-  @happy_path
+  @happy_path @wip
   Scenario: Registration by an individual
     Given I am an individual
      When I register an exemption

--- a/features/front_office/show_exemptions_using_continue_button.feature
+++ b/features/front_office/show_exemptions_using_continue_button.feature
@@ -6,17 +6,18 @@ Feature: Showing exemptions lists using continue button instead of tab
   So that the registration I complete is accurate
   And the choose exemptions page works as I expect
 
-  Scenario: On first tab clicking continue takes me to the next tab
+  Background:
     Given I am on the choose exemptions page
+
+  Scenario: On first tab clicking continue takes me to the next tab
+    
      When I click continue
      Then I will be on the "Using waste" tab
 
   Scenario: Clicking continue without choosing an exemption displays an error
-    Given I am on the choose exemptions page
      When I click continue through the tabs without choosing an exemption
      Then I will be shown a message prompting me to choose an exemption
 
   Scenario: Clicking continue on the last tab takes me to the next page
-    Given I am on the choose exemptions page
      When I click continue on the last tab
      Then I will be on the "reviewing" page

--- a/features/page_objects/login_page.rb
+++ b/features/page_objects/login_page.rb
@@ -1,5 +1,7 @@
 class LoginPage < SitePrism::Page
 
+  set_url(Quke::Quke.config.custom["urls"]["back_office"])
+
   element(:alert_invalid, "div.alert-danger[role='alert']", text: "Invalid email or password")
 
   element(:email, "#user_email")

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -1,11 +1,21 @@
-Given(/^I have a valid username and password$/) do
-
+Given(/^I sign in as a system user$/) do
+  @app = App.new
+  @app.login_page.load
   # Back office login page
   @app.login_page.submit(
     email: Quke::Quke.config.custom["accounts"]["SystemUser"]["username"],
-    password: Quke::Quke.config.custom["accounts"]["SystemUser"]["password"]
+    password: ENV["WEX_DEFAULT_PASSWORD"]
   )
+end
 
+Given(/^I sign in as a super user$/) do
+  @app = App.new
+  @app.login_page.load
+  # Back office login page
+  @app.login_page.submit(
+    email: Quke::Quke.config.custom["accounts"]["SuperUser"]["username"],
+    password: ENV["WEX_DEFAULT_PASSWORD"]
+  )
 end
 
 When(/^I complete a registration$/) do

--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -1,21 +1,8 @@
-Given(/^I am an external user$/) do
 
+Given(/^start a new waste exemption registraton$/) do
   @app = App.new
   @app.front_office_home_page.load
-
-end
-
-Given(/^I am an internal user$/) do
-
-  @app = App.new
-  @app.back_office_home_page.load
-
-end
-
-Given(/^I select a new exemption$/) do
-
   @app.registration_type_page.submit_new
-
 end
 
 When(/^I register an exemption$/) do


### PR DESCRIPTION
Adding Browserstack configuration for updated GDS browser and device versions.
Updating main configuration file to be able to run tests locally for both front and back office.