### PR TITLE
Implement defra-ruby-style

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,73 +1,11 @@
-AllCops:
-  # Cop names are not displayed in offense messages by default. We find it
-  # useful to include this information so we can use it to investigate what the
-  # fix may be.
-  DisplayCopNames: true
-  # Style guide URLs are not displayed in offense messages by default. Again we
-  # find it useful to go straight to the documentation for a rule when
-  # investigating what the fix may be.
-  DisplayStyleGuide: true
+inherit_gem:
+  defra_ruby_style:
+    - default.yml
 
-# We believe it looks cluttered not having the ability to have empty lines after
-# the module, class, and block declarations
-Layout/EmptyLinesAroundBlockBody:
-  Enabled: false
-Layout/EmptyLinesAroundModuleBody:
-  Enabled: false
-Layout/EmptyLinesAroundClassBody:
-  Enabled: false
-
-# We felt as a team that the default size of 15 was too low, and blocked what to
-# us are sound methods which would not add any value if broken up. In this
-# project we've agreed to up this to 30.
-Metrics/AbcSize:
-  Max: 30
-
-# We felt as a team that the default size of 6 was too low, and blocked what to
-# us are sound methods which would not add any value if broken up. In this
-# project we've agreed to up this to 7.
-Metrics/CyclomaticComplexity:
-  Max: 7
-
-# Steps aren't like traditional methods and don't benefit from being broken
-# down. Therefore we exclude them from the block length metric as they often can
-# be long.
+# Our steps are not traditional code blocks and as such rules about there
+# length we don't feel apply. They are a step in a feature and as we want
+# the features to be meaningful, the last thing we want to do is start breaking
+# them up for the sake of this rubocop rule.
 Metrics/BlockLength:
   Exclude:
-    - "**/features/step_definitions/**/*_steps.rb"
-
-# We believe the default of 10 lines for a method length is too restrictive and
-# often quickly hit just because we need to specify the namesspace, class and
-# method before then doing something with it.
-Metrics/MethodLength:
-  Max: 30
-
-# We believe the default 80 characters is too restrictive and that lines can
-# still be readable and maintainable when no more than 120 characters. This also
-# allows us to maximise our screen space.
-Metrics/LineLength:
-  Max: 120
-
-# As long as the team commit to using well named classes it should not be
-# necessary to add top-level class documentation.
-Style/Documentation:
-  Enabled: false
-
-# This rule was added in version 0.49.0. We have nothing against the rule
-# however the code we have it doesn't like is anything that uses strftime().
-# We feel the way we are using that is as expected, so have taken the decision
-# to turn off this cop. https://github.com/bbatsov/rubocop/issues/3438
-Style/FormatStringToken:
-  Enabled: false
-
-# When using Ruby >= 2.3, Rubocop wants to add a comment to the top of *.rb
-# to aid migration to frozen literals in Ruby 3.0. We are not interested in
-# modifying every file at this point, so this cop is disabled for now.
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-# There are no relative performance improvements using '' over "", therefore we
-# believe there is more value in using "" for all strings irrespective of
-# whether string interpolation is used
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
+    - "features/step_definitions/**/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,15 @@
-sudo: false
 language: ruby
-rvm:
-  - 2.4.2
-
+rvm: 2.4.2
+cache: bundler
 # Travis CI clones repositories to a depth of 50 commits, which is only really
 # useful if you are performing git operations.
 # https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth
 git:
   depth: 3
 
-# enable Bundler caching
-# https://docs.travis-ci.com/user/languages/ruby#Caching-Bundler
-cache: bundler
+before_install:
+  - export TZ=UTC
+  - gem install -v 1.17.2 bundler --no-rdoc --no-ri
 
 # Using the ability to customise the Travis build to check for 'temporary' tags
 # i.e. tags often used when working on a feature/scenario but which we don't
@@ -23,3 +21,7 @@ before_script:
   # If grep returns 1 (no match found), test 1 -eq 1 will return 0.
   # If grep returns 2 (error), test 2 -eq 1 will return 1.
   - grep -r --include="*.feature" "@wip\|@focus" features/; test $? -eq 1
+  - bundle exec rubocop
+
+script:
+  - bundle exec rake ci

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gem "quke"
@@ -12,3 +14,7 @@ gem "rake"
 
 # Create random names
 gem "faker"
+
+# Gem used by the Defra ruby services team to ensure a consistent style across
+# our code base
+gem "defra_ruby_style"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,8 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
+    defra_ruby_style (0.0.3)
+      rubocop
     diff-lcs (1.3)
     faker (1.9.3)
       i18n (>= 0.7)
@@ -121,6 +123,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  defra_ruby_style
   faker
   quke
   rake

--- a/Rakefile
+++ b/Rakefile
@@ -1,18 +1,6 @@
 # frozen_string_literal: true
 
-require "rubocop/rake_task"
-
-RuboCop::RakeTask.new
-
 task default: :run
-
-# Remember to create an environment variable in Travis (can be set to anything)!
-if ENV["TRAVIS"]
-  # Setting the default is additive. So if we didn't add the following line
-  # :default would now run both all tests and rubocop
-  Rake::Task[:default].clear
-  task default: [:ci]
-end
 
 desc "Run all scenarios (eq to bundle exec quke)"
 task :run do
@@ -21,7 +9,6 @@ end
 
 desc "Runs the tests used by continuous integration to check the project"
 task :ci do
-  Rake::Task["rubocop"].invoke
   sh %( QUKE_CONFIG=.config-ci.yml bundle exec quke --tags @ci )
 end
 

--- a/config/.config.tst.yml
+++ b/config/.config.tst.yml
@@ -21,7 +21,7 @@ driver: chrome
 # This option only applies when the driver is set to 'chrome' or 'firefox'.
 # Phantomjs is a headless only browser, and option is meaningless for
 # browserstack
-headless: false
+headless: true
 
 # Add a pause (in seconds) between steps so you can visually track how the
 # browser is responding. Only useful if using a non-headless browser. The

--- a/features/hooks/after.rb
+++ b/features/hooks/after.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 After("@backoffice") do
   # As all our back office tests start with logging in we need to ensure that
   # as each back office scenario finishs that we have logged out. Rather than

--- a/features/hooks/before.rb
+++ b/features/hooks/before.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Before("@email") do
   @email_app = EmailApp.new
   if @email_app.local?

--- a/features/page_objects/app.rb
+++ b/features/page_objects/app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Represents all pages in the application. Was created to avoid needing to
 # create individual instances of each page throughout the steps.
 # https://github.com/natritmeyer/site_prism#epilogue

--- a/features/page_objects/applicant_email_page.rb
+++ b/features/page_objects/applicant_email_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicantEmailPage < SitePrism::Page
 
   element(:email, "#applicant_email_form_applicant_email")

--- a/features/page_objects/applicant_name_page.rb
+++ b/features/page_objects/applicant_name_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "faker"
 
 class ApplicantNamePage < SitePrism::Page

--- a/features/page_objects/applicant_phone_page.rb
+++ b/features/page_objects/applicant_phone_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicantPhonePage < SitePrism::Page
 
   element(:tel_number, "#applicant_phone_form_phone_number")

--- a/features/page_objects/back_office/accept_page.rb
+++ b/features/page_objects/back_office/accept_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AcceptPage < SitePrism::Page
 
   element(:password, "#user_password")

--- a/features/page_objects/back_office/confirmation_letter_bulk_exports_page.rb
+++ b/features/page_objects/back_office/confirmation_letter_bulk_exports_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../sections/admin_nav_bar_section"
 
 class ConfirmationLetterBulkExportsPage < SitePrism::Page
@@ -22,14 +24,24 @@ class ConfirmationLetterBulkExportsPage < SitePrism::Page
   section(:nav_bar, AdminNavBarSection, AdminNavBarSection::SELECTOR)
 
   def submit(args = {})
+    populate_from_filter(args)
+    populate_to_filter(args)
+    request_export.click
+  end
+
+  private
+
+  def populate_from_filter(args)
     from_day.select(args[:from_day]) if args.key?(:from_day)
     from_month.select(args[:from_month]) if args.key?(:from_month)
     from_year.select(args[:from_year]) if args.key?(:from_year)
+  end
+
+  def populate_to_filter(args)
     # defaults to current day's date if left blank
     to_day.select(args[:to_day]) if args.key?(:to_day)
     to_month.select(args[:to_month]) if args.key?(:to_month)
     to_year.select(args[:to_year]) if args.key?(:to_year)
-    request_export.click
   end
 
 end

--- a/features/page_objects/back_office/deregister_exemption_page.rb
+++ b/features/page_objects/back_office/deregister_exemption_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../sections/admin_nav_bar_section"
 
 class DeregisterExemptionPage < SitePrism::Page

--- a/features/page_objects/back_office/deregister_registration_page.rb
+++ b/features/page_objects/back_office/deregister_registration_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../sections/admin_nav_bar_section"
 
 class DeregisterRegistrationPage < SitePrism::Page

--- a/features/page_objects/back_office/enrollment_exports_page.rb
+++ b/features/page_objects/back_office/enrollment_exports_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../sections/admin_nav_bar_section"
 
 class EnrollmentExportsPage < SitePrism::Page
@@ -22,14 +24,24 @@ class EnrollmentExportsPage < SitePrism::Page
   section(:nav_bar, AdminNavBarSection, AdminNavBarSection::SELECTOR)
 
   def submit(args = {})
+    populate_from_filter(args)
+    populate_to_filter(args)
+    request_export.click
+  end
+
+  private
+
+  def populate_from_filter(args)
     from_day.select(args[:from_day]) if args.key?(:from_day)
     from_month.select(args[:from_month]) if args.key?(:from_month)
     from_year.select(args[:from_year]) if args.key?(:from_year)
+  end
+
+  def populate_to_filter(args)
     # defaults to current day's date if left blank
     to_day.select(args[:to_day]) if args.key?(:to_day)
     to_month.select(args[:to_month]) if args.key?(:to_month)
     to_year.select(args[:to_year]) if args.key?(:to_year)
-    request_export.click
   end
 
 end

--- a/features/page_objects/back_office/invitation_page.rb
+++ b/features/page_objects/back_office/invitation_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "sections/govuk_banner.rb"
 
 class InvitationPage < SitePrism::Page

--- a/features/page_objects/back_office/login_page.rb
+++ b/features/page_objects/back_office/login_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class LoginPage < SitePrism::Page
 
   set_url(Quke::Quke.config.custom["urls"]["back_office"])

--- a/features/page_objects/back_office/registration_dashboard_page.rb
+++ b/features/page_objects/back_office/registration_dashboard_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "sections/govuk_banner.rb"
 
 class RegistrationDashboardPage < SitePrism::Page

--- a/features/page_objects/back_office/search_page.rb
+++ b/features/page_objects/back_office/search_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SearchPage < SitePrism::Page
 
   element(:alert_signed_in, "div.alert-success[role='alert']", text: "successfully signed in")

--- a/features/page_objects/back_office/sections/govuk_banner.rb
+++ b/features/page_objects/back_office/sections/govuk_banner.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 class GovukBanner < SitePrism::Section
 
   # GOV.UK black banner and menu items
 
-  SELECTOR ||= "#global-header".freeze
+  SELECTOR ||= "#global-header"
 
   element(:home_page, "#proposition-name")
   element(:user_management, "a[href='/users']")

--- a/features/page_objects/back_office/users_page.rb
+++ b/features/page_objects/back_office/users_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "sections/govuk_banner.rb"
 
 class UsersPage < SitePrism::Page

--- a/features/page_objects/business_type_page.rb
+++ b/features/page_objects/business_type_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class BusinessTypePage < SitePrism::Page
 
   element(:individual, "#business_type_form_business_type_soletrader + label")
@@ -10,20 +12,11 @@ class BusinessTypePage < SitePrism::Page
   element(:submit_button, "input[name='commit']")
 
   def submit(args = {})
-    case args[:business_type]
-    when :individual
-      individual.select_option
-    when :limited
-      limited.select_option
-    when :partnership
-      partnership.select_option
-    when :llp
-      llp.select_option
-    when :local_authority
-      local_authority.select_option
-    when :charity
-      charity.select_option
-    end
+    # As long as the arg passed in matches the name of an element we can simply
+    # invoke the element using ruby's send() method. In this way we can avoid
+    # overly long case/switch statements that check the value of the arg to
+    # determine which element to select
+    send(args[:business_type]).select_option
 
     submit_button.click
   end

--- a/features/page_objects/check_details_page.rb
+++ b/features/page_objects/check_details_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CheckDetailsPage < SitePrism::Page
 
   # Contact details

--- a/features/page_objects/choose_exemptions_page.rb
+++ b/features/page_objects/choose_exemptions_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChooseExemptionsPage < SitePrism::Page
 
   elements(:exemptions, "input[name='exemptions_form[exemptions][]']", visible: false)

--- a/features/page_objects/company_name_page.rb
+++ b/features/page_objects/company_name_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CompanyNamePage < SitePrism::Page
   element(:company_name, "#name")
   element(:submit_button, "input[name='commit']")

--- a/features/page_objects/confirmation_page.rb
+++ b/features/page_objects/confirmation_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ConfirmationPage < SitePrism::Page
 
   # .text method exposes reference number

--- a/features/page_objects/contact_address_page.rb
+++ b/features/page_objects/contact_address_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ContactAddressPage < SitePrism::Page
 
   element(:postcode, "#contact_postcode_form_postcode")

--- a/features/page_objects/contact_email_page.rb
+++ b/features/page_objects/contact_email_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ContactEmailPage < SitePrism::Page
 
   element(:email, "#contact_email_form_contact_email")

--- a/features/page_objects/contact_name_page.rb
+++ b/features/page_objects/contact_name_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ContactNamePage < SitePrism::Page
 
   element(:first_name, "#contact_name_form_first_name")

--- a/features/page_objects/contact_position_page.rb
+++ b/features/page_objects/contact_position_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ContactPositionPage < SitePrism::Page
 
   element(:position, "#contact_position_form_position")

--- a/features/page_objects/contact_telephone_page.rb
+++ b/features/page_objects/contact_telephone_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ContactTelephonePage < SitePrism::Page
 
   element(:tel_no, "#contact_phone_form_phone_number")

--- a/features/page_objects/declaration_page.rb
+++ b/features/page_objects/declaration_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DeclarationPage < SitePrism::Page
 
   element(:declaration_checkbox, "#declaration_form_declaration+ label")

--- a/features/page_objects/email/email_app.rb
+++ b/features/page_objects/email/email_app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Represents all pages in the front office. Was created to avoid needing to
 # create individual instances of each page throughout the steps.
 # https://github.com/natritmeyer/site_prism#epilogue

--- a/features/page_objects/email/mailcatcher_main_page.rb
+++ b/features/page_objects/email/mailcatcher_main_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MailcatcherMainPage < SitePrism::Page
 
   set_url(Quke::Quke.config.custom["urls"]["mail_client"])

--- a/features/page_objects/email/mailcatcher_messages_page.rb
+++ b/features/page_objects/email/mailcatcher_messages_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MailcatcherMessagesPage < SitePrism::Page
 
   element(:confirmation_link, "#confirmation_link")

--- a/features/page_objects/email/mailinator_email_details_page.rb
+++ b/features/page_objects/email/mailinator_email_details_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MailinatorEmailDetailsPage < SitePrism::Page
   # Mailinator email details page
   element(:confirm_email, "#confirmation_link")

--- a/features/page_objects/email/mailinator_inbox_page.rb
+++ b/features/page_objects/email/mailinator_inbox_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MailinatorInboxPage < SitePrism::Page
   # Mailinator inbox
   element(:registration_complete_email, :xpath, "//*[normalize-space()='Waste exemptions registration']")

--- a/features/page_objects/email/mailinator_page.rb
+++ b/features/page_objects/email/mailinator_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MailinatorPage < SitePrism::Page
   # Mailinator email checker main page
   set_url(Quke::Quke.config.custom["urls"]["mail_client"])

--- a/features/page_objects/farmer_page.rb
+++ b/features/page_objects/farmer_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class FarmerPage < SitePrism::Page
 
   # Is the person carrying out the waste operation a farmer?

--- a/features/page_objects/front_office_home_page.rb
+++ b/features/page_objects/front_office_home_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class FrontOfficeHomePage < SitePrism::Page
 
   set_url("/")

--- a/features/page_objects/location_page.rb
+++ b/features/page_objects/location_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class LocationPage < SitePrism::Page
 
   element(:england, "#location_form_location_england + label")

--- a/features/page_objects/main_people_page.rb
+++ b/features/page_objects/main_people_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "faker"
 
 class MainPeoplePage < SitePrism::Page

--- a/features/page_objects/on_farm_page.rb
+++ b/features/page_objects/on_farm_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class OnFarmPage < SitePrism::Page
 
   # Will this waste operation take place on a farm?

--- a/features/page_objects/operator_address_page.rb
+++ b/features/page_objects/operator_address_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class OperatorAddressPage < SitePrism::Page
 
   element(:house_no, "#operator_address_manual_form_premises")

--- a/features/page_objects/operator_name_page.rb
+++ b/features/page_objects/operator_name_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class OperatorNamePage < SitePrism::Page
 
   element(:org_name, "#operator_name_form_operator_name", visible: false)

--- a/features/page_objects/register_in_wales_page.rb
+++ b/features/page_objects/register_in_wales_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RegisterInWalesPage < SitePrism::Page
 
   # You cannot register your exemption here

--- a/features/page_objects/registration_number_page.rb
+++ b/features/page_objects/registration_number_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RegistrationNumberPage < SitePrism::Page
   element(:registration_number, "#registration_number_form_company_no")
 

--- a/features/page_objects/registration_type_page.rb
+++ b/features/page_objects/registration_type_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RegistrationTypePage < SitePrism::Page
 
   element(:new_registration, "#start_form_start_new + label")

--- a/features/page_objects/reviewing_partners_page.rb
+++ b/features/page_objects/reviewing_partners_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ReviewingPartnersPage < SitePrism::Page
   element(:add_partner, ".form-group .ignore-visited")
 

--- a/features/page_objects/sections/admin_nav_bar_section.rb
+++ b/features/page_objects/sections/admin_nav_bar_section.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AdminNavBarSection < SitePrism::Section
 
   # IMPORTANT! Because of the way the nav-bar works in order to see the options
@@ -17,7 +19,7 @@ class AdminNavBarSection < SitePrism::Section
   # When adding it to your pages use
   # section(:nav_bar, AdminNavBarSection, AdminNavBarSection::SELECTOR)
 
-  SELECTOR ||= ".add-bottom-margin .container".freeze
+  SELECTOR ||= ".add-bottom-margin .container"
 
   element(:home_link, "a.navbar-brand")
 

--- a/features/page_objects/sections/exemption_details_section.rb
+++ b/features/page_objects/sections/exemption_details_section.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ExemptionDetailsSection < SitePrism::Section
 
   # IMPORTANT! The section is hidden when the page is first loaded you, so to
@@ -13,7 +15,7 @@ class ExemptionDetailsSection < SitePrism::Section
   # When adding it to your pages use
   # section(:exemption_details, ExemptionDetailsSection, ExemptionDetailsSection::SELECTOR)
 
-  SELECTOR ||= ".col-sm-9 .row:nth-child(3) .panel-default".freeze
+  SELECTOR ||= ".col-sm-9 .row:nth-child(3) .panel-default"
 
   element(:expander_link, "a[href='#exemption-details']")
 

--- a/features/page_objects/sections/registration_details_section.rb
+++ b/features/page_objects/sections/registration_details_section.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RegistrationDetailsSection < SitePrism::Section
 
   # IMPORTANT! This section is visible when the page is first loaded, so you
@@ -11,7 +13,7 @@ class RegistrationDetailsSection < SitePrism::Section
   # When adding it to your pages use
   # section(:registration_details, RegistrationDetailsSection, RegistrationDetailsSection::SELECTOR)
 
-  SELECTOR ||= ".col-sm-9 .row:nth-child(2) .panel-default".freeze
+  SELECTOR ||= ".col-sm-9 .row:nth-child(2) .panel-default"
 
   element(:expander_link, "a[href='#registration-details']")
 

--- a/features/page_objects/sections/site_details_section.rb
+++ b/features/page_objects/sections/site_details_section.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SiteDetailsSection < SitePrism::Section
 
   # IMPORTANT! The section is hidden when the page is first loaded you, so to
@@ -13,7 +15,7 @@ class SiteDetailsSection < SitePrism::Section
   # When adding it to your pages use
   # section(:site_details, SiteDetailsSection, SiteDetailsSection::SELECTOR)
 
-  SELECTOR ||= ".col-sm-9 .row:nth-child(4) .panel-default".freeze
+  SELECTOR ||= ".col-sm-9 .row:nth-child(4) .panel-default"
 
   element(:expander_link, "a[href='#site-details']")
 

--- a/features/page_objects/site_address_page.rb
+++ b/features/page_objects/site_address_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SiteAddressPage < SitePrism::Page
 
   element(:postcode, "#site_postcode_form_postcode")

--- a/features/page_objects/site_grid_reference_page.rb
+++ b/features/page_objects/site_grid_reference_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SiteGridReferencePage < SitePrism::Page
 
   element(:postcode, "input[id='find_address']")

--- a/features/step_definitions/back_office/assisted_digital_charity_registration_steps.rb
+++ b/features/step_definitions/back_office/assisted_digital_charity_registration_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 When(/^I complete a charities registration$/) do
   @email_address = generate_email
   @app.registration_dashboard_page.create_new_registration.click

--- a/features/step_definitions/back_office/assisted_digital_individual_registration_steps.rb
+++ b/features/step_definitions/back_office/assisted_digital_individual_registration_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 When(/^I complete an individuals registration$/) do
   @email_address = generate_email
   @app.registration_dashboard_page.create_new_registration.click

--- a/features/step_definitions/back_office/assisted_digital_limited_company_registration_steps.rb
+++ b/features/step_definitions/back_office/assisted_digital_limited_company_registration_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 When(/I complete a limited companies registration$/) do
   @email_address = generate_email
   @app.registration_dashboard_page.create_new_registration.click

--- a/features/step_definitions/back_office/assisted_digital_llp_registration_steps.rb
+++ b/features/step_definitions/back_office/assisted_digital_llp_registration_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 When(/^I complete an LLPs registration$/) do
   @email_address = generate_email
   @app.registration_dashboard_page.create_new_registration.click

--- a/features/step_definitions/back_office/assisted_digital_local_authority_registration_steps.rb
+++ b/features/step_definitions/back_office/assisted_digital_local_authority_registration_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 When(/^I complete a local authorities registration$/) do
   @email_address = generate_email
   @app.registration_dashboard_page.create_new_registration.click

--- a/features/step_definitions/back_office/assisted_digital_partnership_registration_steps.rb
+++ b/features/step_definitions/back_office/assisted_digital_partnership_registration_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 When(/^I complete a partnerships registration$/) do
   @email_address = generate_email
   @app.registration_dashboard_page.create_new_registration.click

--- a/features/step_definitions/back_office/dashboard_steps.rb
+++ b/features/step_definitions/back_office/dashboard_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 When(/^I search for "([^"]*)"$/) do |term|
   @app.registration_dashboard_page.submit(search_term: term)
 end

--- a/features/step_definitions/back_office/deregister_steps.rb
+++ b/features/step_definitions/back_office/deregister_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 When(/^I "([^"]*)" an exemption$/) do |status|
 
   @app.search_page.nav_bar.home_link.click

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 When(/^I complete a registration using postcode (.*) for the site address$/) do |postcode|
   @app.search_page.nav_bar.registrations_menu.click
   @app.search_page.nav_bar.new_option.click

--- a/features/step_definitions/back_office/sign_in_steps.rb
+++ b/features/step_definitions/back_office/sign_in_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Given(/^I sign in as a system user$/) do
   @app = App.new
   @app.login_page.load

--- a/features/step_definitions/back_office/user_management_steps.rb
+++ b/features/step_definitions/back_office/user_management_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 When(/^I am on the waste exemptions dashboard$/) do
   expect(@app.registration_dashboard_page).to have_text("Waste exemptions dashboard")
 end

--- a/features/step_definitions/continuous_integration_steps.rb
+++ b/features/step_definitions/continuous_integration_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Given(/^a cucumber that is (\d+) cm long$/) do |length|
   @cucumber = { color: "green", length: length.to_i }
 end

--- a/features/step_definitions/email_steps.rb
+++ b/features/step_definitions/email_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Then(/^I will receive a confirmation email$/) do
   if @email_app.local?
     @email_app.mailcatcher_main_page.load

--- a/features/step_definitions/front_office/charity_steps.rb
+++ b/features/step_definitions/front_office/charity_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Given(/^I am a charity$/) do
   @app.location_page.submit(location: :england)
   people = @app.applicant_name_page.applicant

--- a/features/step_definitions/front_office/individual_steps.rb
+++ b/features/step_definitions/front_office/individual_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Given(/^I am an individual$/) do
   @app.location_page.submit(location: :england)
   people = @app.applicant_name_page.applicant

--- a/features/step_definitions/front_office/limited_company_steps.rb
+++ b/features/step_definitions/front_office/limited_company_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Given(/^I am a limited company$/) do
   @app.location_page.submit(location: :england)
   people = @app.applicant_name_page.applicant

--- a/features/step_definitions/front_office/limited_liability_partnership_steps.rb
+++ b/features/step_definitions/front_office/limited_liability_partnership_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Given(/^I am a limited liability partnership$/) do
   @app.location_page.submit(location: :england)
   people = @app.applicant_name_page.applicant

--- a/features/step_definitions/front_office/local_authority_steps.rb
+++ b/features/step_definitions/front_office/local_authority_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Given(/^I am a local authority$/) do
   @app.location_page.submit(location: :england)
   people = @app.applicant_name_page.applicant

--- a/features/step_definitions/front_office/location_steps.rb
+++ b/features/step_definitions/front_office/location_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Given(/^I choose Wales$/) do
   @app.location_page.submit(location: :wales)
 end

--- a/features/step_definitions/front_office/partnership_steps.rb
+++ b/features/step_definitions/front_office/partnership_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Given(/^I am a partnership$/) do
   @app.location_page.submit(location: :england)
   people = @app.applicant_name_page.applicant

--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Given(/^I start a new waste exemption registraton$/) do
   @app = App.new
   @email_address = generate_email

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 def generate_email
   @email_address = rand(100_000_000).to_s + "@mailinator.com"
 end


### PR DESCRIPTION
This implements [Defra Ruby Style](https://github.com/DEFRA/defra-ruby-style) which is a Defra gem used for managing our rubocop rules and configuration across projects.

Along with implementing the gem this change resolves issues found when running the new rules. Finally we made some tweaks to the Travis CI config to bring the project more inline with other and to reduce the complexity in the `Rakefile`.