### PR TITLE
Add cover for resume a registration

### DIFF
--- a/features/back_office/user_roles.feature
+++ b/features/back_office/user_roles.feature
@@ -11,6 +11,7 @@ Feature: Back office users have different roles with different permissions
       And I can access create a new registration
       And I can search for registrations
       And I can view their details
+      And I can continue an in progress registration
 
   Scenario: User is a super_agent
     Given I sign in as a super agent
@@ -20,6 +21,7 @@ Feature: Back office users have different roles with different permissions
       And I can access create a new registration
       But I can search for registrations
       And I can view their details
+      And I can continue an in progress registration
 
   Scenario: User is an admin_agent
     Given I sign in as an admin agent
@@ -29,6 +31,7 @@ Feature: Back office users have different roles with different permissions
       And I can access create a new registration
       And I can search for registrations
       And I can view their details
+      And I can continue an in progress registration
 
   Scenario: User is an data_agent
     Given I sign in as an data agent
@@ -38,3 +41,4 @@ Feature: Back office users have different roles with different permissions
       And I cannot access create a new registration
       But I can search for registrations
       And I can view their details
+      But I cannot continue an in progress registration

--- a/features/page_objects/back_office/dashboard_page.rb
+++ b/features/page_objects/back_office/dashboard_page.rb
@@ -19,6 +19,8 @@ class DashboardPage < SitePrism::Page
 
   elements(:results, ".registration-list")
 
+  elements(:resume_links, "[id^=resume]")
+
   def view_link(registration_number)
     find(:css, "#view_#{registration_number}")
   end

--- a/features/step_definitions/back_office/user_roles_steps.rb
+++ b/features/step_definitions/back_office/user_roles_steps.rb
@@ -51,16 +51,23 @@ Then("I cannot access create a new registration") do
 end
 
 Then("I can view their details") do
-  # result = @world.bo.dashboard_page.results[0]
-  # within(@world.bo.dashboard_page.results[0]) do
-  #   puts "Hello1 #{result.path}"
-  #   puts "Hello2 #{result.tag_name}"
-  #   puts "Hello4 #{result.text}"
-  #   puts "Hello5 #{result.value}"
-  #   click_link("[id^=view_WEX]")
-  # end
   @world.bo.dashboard_page.view_link(@world.known_reg_no).click
-  # @world.bo.dashboard_page.results[0].details_link.click
   expect(page).to have_content("Registration details for")
   expect(page).to have_current_path(%r{^\/registrations\/WEX})
+end
+
+Then("I can continue an in progress registration") do
+  @world.bo.dashboard_page.load
+  @world.bo.dashboard_page.unsubmitted_filter.click
+  @world.bo.dashboard_page.submit(search_term: "Mr Waste")
+  @world.bo.dashboard_page.resume_links[0].click
+
+  expect(page).to have_content("Who should we contact about this waste exemption operation?")
+end
+
+Then("I cannot continue an in progress registration") do
+  @world.bo.dashboard_page.load
+  @world.bo.dashboard_page.unsubmitted_filter.click
+  @world.bo.dashboard_page.submit(search_term: "Mr Waste")
+  expect(@world.bo.dashboard_page.resume_links.count).to eq(0)
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-199

If an external user starts a registration but isn't able to complete it, and they call NCCC for help, NCCC staff should be able to pick it up and continue working on it.

We have added the functionality for resuming a registration from the back office so this change provides acceptance test cover of it.