### PR TITLE
Remove rubocop dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,6 @@ gem "quke",
     git: "https://github.com/DEFRA/quke",
     branch: "master"
 
-# We use rubocop in all our Ruby based projects to try and ensure consistency
-# in the code we write across all our projects.
-gem "rubocop", require: false
-
 # Rake gives us the ability to create our own commands or 'tasks' for working
 # with quke.
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,6 @@ DEPENDENCIES
   faker
   quke!
   rake
-  rubocop
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
Rubocop is now brought by the dependency [defra_ruby_style](https://github.com/DEFRA/defra-ruby-style) and as such no longer needs its own reference in the Gemfile.