### PR TITLE
Fix BO create reg using front office

### DIFF
--- a/features/step_definitions/back_office/registration_steps.rb
+++ b/features/step_definitions/back_office/registration_steps.rb
@@ -6,7 +6,7 @@ Then("I complete a limited companies registration") do
   @world.current_reg = generate_registration(:limited)
 
   # Stores the exemption number so the exemption can be edited in later steps
-  @world.last_reference = add_submitted_registration(@world.current_reg)
+  @world.last_reference = add_submitted_registration(@world.current_reg, false)
 end
 
 Then("I complete a partnerships registration") do
@@ -15,5 +15,5 @@ Then("I complete a partnerships registration") do
   @world.current_reg = generate_registration(:partnership)
 
   # Stores the exemption number so the exemption can be edited in later steps
-  @world.last_reference = add_submitted_registration(@world.current_reg)
+  @world.last_reference = add_submitted_registration(@world.current_reg, false)
 end


### PR DESCRIPTION
We spotted that there was an inconsistency with the back office create registration feature. After clicking the link in the back office to start a new registration it was then switching to the front office to actually complete the journey.

We had simply forgotten to pass in the param to tell the `add_submitted_registration()` method not to load the homepage when it starts.