### PR TITLE
Fix typo and update defaults in config files

### DIFF
--- a/config/dev.config.yml
+++ b/config/dev.config.yml
@@ -21,7 +21,7 @@ driver: chrome
 # This option only applies when the driver is set to 'chrome' or 'firefox'.
 # Phantomjs is a headless only browser, and option is meaningless for
 # browserstack
-headless: true
+headless: false
 
 # Add a pause (in seconds) between steps so you can visually track how the
 # browser is responding. Only useful if using a non-headless browser. The
@@ -69,7 +69,7 @@ javascript_errors: false
 # If you don't need to see the detail on each run, this might be easier to
 # follow than the detailed output you see using the default 'pretty' print
 # format.
-print_progress: true
+print_progress: false
 
 # Tell Quke you want to run tests in parallel. This will make use of the
 # available cores on your machine to run the tests in parallel, reducing the
@@ -79,8 +79,8 @@ print_progress: true
 # egligible if you only have a few). However your scenarios must be independent,
 # and the console output will be 'number of processes' * cucumber output. So
 # this is best used if you are just after a simple pass/fail result.
-parrellel:
-  enable: true
+parallel:
+  enable: false
   # The available options are based on those the ParallelTests gem supports
   #
   # - found - order of finding files

--- a/config/loc.config.yml
+++ b/config/loc.config.yml
@@ -69,7 +69,7 @@ javascript_errors: false
 # If you don't need to see the detail on each run, this might be easier to
 # follow than the detailed output you see using the default 'pretty' print
 # format.
-print_progress: true
+print_progress: false
 
 # Tell Quke you want to run tests in parallel. This will make use of the
 # available cores on your machine to run the tests in parallel, reducing the
@@ -79,7 +79,7 @@ print_progress: true
 # egligible if you only have a few). However your scenarios must be independent,
 # and the console output will be 'number of processes' * cucumber output. So
 # this is best used if you are just after a simple pass/fail result.
-parrellel:
+parallel:
   enable: false
   # The available options are based on those the ParallelTests gem supports
   #

--- a/config/pre.config.yml
+++ b/config/pre.config.yml
@@ -21,7 +21,7 @@ driver: chrome
 # This option only applies when the driver is set to 'chrome' or 'firefox'.
 # Phantomjs is a headless only browser, and option is meaningless for
 # browserstack
-headless: true
+headless: false
 
 # Add a pause (in seconds) between steps so you can visually track how the
 # browser is responding. Only useful if using a non-headless browser. The
@@ -69,7 +69,7 @@ javascript_errors: false
 # If you don't need to see the detail on each run, this might be easier to
 # follow than the detailed output you see using the default 'pretty' print
 # format.
-print_progress: true
+print_progress: false
 
 # Tell Quke you want to run tests in parallel. This will make use of the
 # available cores on your machine to run the tests in parallel, reducing the
@@ -79,8 +79,8 @@ print_progress: true
 # egligible if you only have a few). However your scenarios must be independent,
 # and the console output will be 'number of processes' * cucumber output. So
 # this is best used if you are just after a simple pass/fail result.
-parrellel:
-  enable: true
+parallel:
+  enable: false
   # The available options are based on those the ParallelTests gem supports
   #
   # - found - order of finding files

--- a/config/tst.config.yml
+++ b/config/tst.config.yml
@@ -21,7 +21,7 @@ driver: chrome
 # This option only applies when the driver is set to 'chrome' or 'firefox'.
 # Phantomjs is a headless only browser, and option is meaningless for
 # browserstack
-headless: true
+headless: false
 
 # Add a pause (in seconds) between steps so you can visually track how the
 # browser is responding. Only useful if using a non-headless browser. The
@@ -69,7 +69,7 @@ javascript_errors: false
 # If you don't need to see the detail on each run, this might be easier to
 # follow than the detailed output you see using the default 'pretty' print
 # format.
-print_progress: true
+print_progress: false
 
 # Tell Quke you want to run tests in parallel. This will make use of the
 # available cores on your machine to run the tests in parallel, reducing the
@@ -79,8 +79,8 @@ print_progress: true
 # egligible if you only have a few). However your scenarios must be independent,
 # and the console output will be 'number of processes' * cucumber output. So
 # this is best used if you are just after a simple pass/fail result.
-parrellel:
-  enable: true
+parallel:
+  enable: false
   # The available options are based on those the ParallelTests gem supports
   #
   # - found - order of finding files


### PR DESCRIPTION
We spotted that there was a typo in the name of the parallel section in all 4 environment `.config.yml` files.

This change fixes that, but also updates some of the defaults to match current preferences

- use headless is now `false`
- print_progress is now `false`
- enable parallel is now `false`

The project is being picked up by a new QA (👋 @andrewhick ) and as such running with these defaults will give a better sense of what is going on.