### PR TITLE
Add data exports check to user roles feature

### DIFF
--- a/features/back_office/user_roles.feature
+++ b/features/back_office/user_roles.feature
@@ -12,6 +12,7 @@ Feature: Back office users have different roles with different permissions
       And I can search for registrations
       And I can view their details
       And I can continue an in progress registration
+      And I can access data exports
 
   Scenario: User is a super_agent
     Given I sign in as a super agent
@@ -22,6 +23,7 @@ Feature: Back office users have different roles with different permissions
       But I can search for registrations
       And I can view their details
       And I can continue an in progress registration
+      And I can access data exports
 
   Scenario: User is an admin_agent
     Given I sign in as an admin agent
@@ -32,6 +34,7 @@ Feature: Back office users have different roles with different permissions
       And I can search for registrations
       And I can view their details
       And I can continue an in progress registration
+      And I can access data exports
 
   Scenario: User is an data_agent
     Given I sign in as an data agent
@@ -42,3 +45,4 @@ Feature: Back office users have different roles with different permissions
       But I can search for registrations
       And I can view their details
       But I cannot continue an in progress registration
+      But I can access data exports

--- a/features/page_objects/back_office/sections/admin_menu_section.rb
+++ b/features/page_objects/back_office/sections/admin_menu_section.rb
@@ -8,5 +8,6 @@ class AdminMenuSection < SitePrism::Section
 
   element(:home_page, "#proposition-name")
   element(:user_management, "a[href='/users']")
+  element(:data_exports, "a[href='/data-exports']")
 
 end

--- a/features/step_definitions/back_office/user_roles_steps.rb
+++ b/features/step_definitions/back_office/user_roles_steps.rb
@@ -71,3 +71,11 @@ Then("I cannot continue an in progress registration") do
   @world.bo.dashboard_page.submit(search_term: "Mr Waste")
   expect(@world.bo.dashboard_page.resume_links.count).to eq(0)
 end
+
+Then("I can access data exports") do
+  @world.bo.dashboard_page.load
+  expect(@world.bo.dashboard_page.admin_menu).to have_data_exports
+
+  @world.bo.dashboard_page.admin_menu.data_exports.click
+  expect(find("h1.heading-large").text).to eq("Data Exports")
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-68

This change adds steps that confirm all user roles have access to the data exports page and that when they click through to it the page loads.

It's difficult to go beyond this because the content is very dependent on what data was created when in the database, but hopefully this is sufficient to at least confirm the page is up and the permissions are correct.