### PR TITLE
Feature/confirmation letter

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -44,7 +44,7 @@ end
 
 desc "Run tests against the test environment with custom tags"
 task :tsttag do
-  sh %( QUKE_CONFIG=config/tst.config.yml bundle exec quke --tags @email)
+  sh %( QUKE_CONFIG=config/tst.config.yml bundle exec quke --tags @wip)
 end
 
 desc "Run all @wip tests against the test environment"

--- a/Rakefile
+++ b/Rakefile
@@ -57,6 +57,16 @@ task :pre do
   sh %( QUKE_CONFIG=config/pre.config.yml bundle exec quke --tags @smoke)
 end
 
+desc "Run all tests against the production environment"
+task :prd do
+  sh %( QUKE_CONFIG=config/prd.config.yml bundle exec quke --tags ~@email)
+end
+
+desc "Run tests against the prod environment with custom tags"
+task :prdtag do
+  sh %( QUKE_CONFIG=config/prd.config.yml bundle exec quke --tags @wip)
+end
+
 desc "Run all browserstack tests"
 task browserstack: %i[
   chrome70_osx

--- a/config/loc.config.yml
+++ b/config/loc.config.yml
@@ -21,7 +21,7 @@ driver: chrome
 # This option only applies when the driver is set to 'chrome' or 'firefox'.
 # Phantomjs is a headless only browser, and option is meaningless for
 # browserstack
-headless: false
+headless: true
 
 # Add a pause (in seconds) between steps so you can visually track how the
 # browser is responding. Only useful if using a non-headless browser. The

--- a/config/prd.config.yml
+++ b/config/prd.config.yml
@@ -1,0 +1,128 @@
+# The standard place to add your features and step_definitions is in a folder
+# named 'features' at the root of the project. However if you'd like to name
+# this folder something else, you can tell Quke what the new name is here.
+# The default is features
+# features_folder: 'cukes'
+
+# Normally Capybara expects to be testing an in-process Rack application, but
+# we're using it to talk to a remote host. Users of Quke can set what this
+# will be by simply setting `app_host`. You can then use it directly using
+# Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
+# the full url each time
+app_host: "https://wex-prd.aws.defra.cloud"
+
+# Tells Quke which browser to use for testing. Choices are firefox, chrome
+# browserstack and phantomjs, with the default being phantomjs
+driver: chrome
+
+# Let Quke know you want to run the browser in headless mode. Headless mode
+# means the browser still runs but you won't see it displayed. The benefit is
+# that your tests will take less time as it's less resource intensive.
+# This option only applies when the driver is set to 'chrome' or 'firefox'.
+# Phantomjs is a headless only browser, and option is meaningless for
+# browserstack
+headless: false
+
+# Add a pause (in seconds) between steps so you can visually track how the
+# browser is responding. Only useful if using a non-headless browser. The
+# default is 0
+pause: 0
+
+# Specify whether Quke should stop all tests once an error occurs. Useful in
+# Continuous Integration (CI) environments where a quick Yes/No is preferable to
+# a detailed response. By default Quke sets this to false if not set in the
+# config.
+#
+# If you are running in parallel mode this gets applied to each process spawned.
+# So if 4 processes are spawned and one of them errors, only the one that errors
+# will be stopped.
+stop_on_error: true
+
+# By default Quke will display web pages where a failure has taken place.
+# A copy of the html is saved and Quke will display it in your default browser.
+# This can be useful to diagnose why something has failed, but there are times
+# you may not want Quke to do this.
+#
+# Please note, if the driver is phantomjs or the `headless` is true nothing will
+# be displayed even if this is set to true.
+display_failures: false
+
+# Capybara will attempt to find an element for a period of time, rather than
+# immediately failing because the element cannot be found. This defaults to 2
+# seconds. However if the site you are working with is slow or features
+# elements that take some time to load you can increase this default.
+max_wait_time: 5
+
+# Currently only supported when using the phantomjs driver (ignored by the
+# others). In phantomjs if a site has a javascript error we can configure it
+# to throw an error which will cause the test to fail. Quke by default sets this
+# to true, however you can override it by setting this flag to false.
+# For example you may be dealing with a legacy site and JavaScript errors
+# are out of your scope. You still want to test other aspects of the site
+# but not let these errors prevent you from using phantomjs.
+javascript_errors: false
+
+# If set Quke will tell Cucumber to output to the console using its
+# 'progress' formatter (simply displays a . for each passing scenario and F for
+# each failing one), rather than the default 'pretty' which displays each
+# scenario in detail.
+# If you don't need to see the detail on each run, this might be easier to
+# follow than the detailed output you see using the default 'pretty' print
+# format.
+print_progress: false
+
+# Tell Quke you want to run tests in parallel. This will make use of the
+# available cores on your machine to run the tests in parallel, reducing the
+# time it takes them to run.
+#
+# This is great if you have a large test suite (the performance improvement is
+# egligible if you only have a few). However your scenarios must be independent,
+# and the console output will be 'number of processes' * cucumber output. So
+# this is best used if you are just after a simple pass/fail result.
+parallel:
+  enable: false
+  # The available options are based on those the ParallelTests gem supports
+  #
+  # - found - order of finding files
+  # - steps - number of cucumber/spinach steps
+  # - scenarios - individual cucumber scenarios
+  # - filesize - by size of the file
+  # - runtime - info from runtime log
+  # - default - runtime when runtime log is filled otherwise filesize
+  #
+  # N.B. For cucumber the default actually seems to be number of feature files.
+  #
+  # The reason this is available is to allow you to fine tune your test runs.
+  # If you have a test suite which involves features that have 1 scenario, and
+  # others that have many, you may wish to group by scenario instead of the
+  # default features in order to balance what gets assigned to what processes
+  # https://github.com/grosser/parallel_tests#setup-for-non-rails
+  group_by: scenarios
+
+# Anything you place under the 'custom' node in the `.config.yml` file will be
+# available within your steps and page objects by calling
+# `Quke::Quke.config.custom`. So using the example below we could access its
+# values in the following ways
+#
+# Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
+# Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+#
+# As long as what you add is valid YAML (check with a tool like
+# http://www.yamllint.com/) Quke will be able to pick it up and make it
+# available in your tests.
+custom:
+  accounts:
+    DataAgent:
+      username: data_agent@wex.gov.uk
+    AdminAgent:
+      username: admin_agent@wex.gov.uk
+    SuperAgent:
+      username: super_agent@wex.gov.uk
+    SystemUser:
+      username: system_user@wex.gov.uk
+  urls:
+    front_office: "https://wex-prd.aws.defra.cloud"
+    back_office: "https://admin-wex-prd.aws.defra.cloud"
+    back_office_email: "https://admin-wex-prd.aws.defra.cloud/last-email"
+    mail_client: "https://wex-prd.aws.defra.cloud/last-email"

--- a/config/tst.config.yml
+++ b/config/tst.config.yml
@@ -45,7 +45,7 @@ stop_on_error: true
 #
 # Please note, if the driver is phantomjs or the `headless` is true nothing will
 # be displayed even if this is set to true.
-display_failures: false
+display_failures: true
 
 # Capybara will attempt to find an element for a period of time, rather than
 # immediately failing because the element cannot be found. This defaults to 2

--- a/features/back_office/deregister.feature
+++ b/features/back_office/deregister.feature
@@ -1,4 +1,4 @@
-@backoffice
+@backoffice @data
 Feature: Back office user deregisters exemptions
   As an admin agent
   I need to deregister a waste exemption activity

--- a/features/back_office/edit.feature
+++ b/features/back_office/edit.feature
@@ -1,0 +1,26 @@
+@backoffice
+Feature: Back office user edits a registration
+  As an super admin agent
+  I need to edit a waste exemption registration
+  So that I can keep it up to date
+
+  Background: Register an exemption
+    Given I am a limited company
+     When I register an exemption
+     Then I will be informed the registration is complete
+
+  Scenario: [RUBY-62] Edit a registration
+    Given I sign in as a super agent
+     When I edit the most recent registration
+      And I complete the edit
+     Then I can see the new details on the registration details page
+
+  Scenario: Negative access test
+     When I sign in as an admin agent
+     Then I cannot edit the most recent registration
+
+  Scenario: Cancel registration
+   Given I sign in as a super agent
+    When I edit the most recent registration
+     And I cancel the edit
+    Then I cannot see the new details on the registration details page

--- a/features/back_office/search.feature
+++ b/features/back_office/search.feature
@@ -7,10 +7,16 @@ Feature: Back office users need to be able to search for registrations
   Background:
 	  Given I sign in as an admin agent
 
+  Scenario: [RUBY-66] Confirmation letter
+     When The "submitted" search filter is selected
+      And I search for "a known registration"
+     Then I can see a confirmation letter for a known registration
+
   Scenario: Submitted registrations
      When The "submitted" search filter is selected
       And I search for "Mr Waste"
      Then I see "Mr Waste submitted" in the results
+      And I can see confirmation letter links
       But I don't see "Mr Waste unsubmitted"
 
   Scenario: Unsubmitted registrations
@@ -18,3 +24,4 @@ Feature: Back office users need to be able to search for registrations
       And I search for "Mr Waste"
      Then I see "Mr Waste unsubmitted" in the results
       But I don't see "Mr Waste submitted"
+      And I cannot see a confirmation letter

--- a/features/page_objects/apps/back_office_app.rb
+++ b/features/page_objects/apps/back_office_app.rb
@@ -31,6 +31,14 @@ class BackOfficeApp
     @last_page = DeactivateUserPage.new
   end
 
+  def edit_page
+    @last_page = EditPage.new
+  end
+
+  def edit_details_page
+    @last_page = EditDetailsPage.new
+  end
+
   def invitation_page
     @last_page = InvitationPage.new
   end

--- a/features/page_objects/apps/back_office_app.rb
+++ b/features/page_objects/apps/back_office_app.rb
@@ -15,6 +15,10 @@ class BackOfficeApp
     @last_page = ChangeUserRolePage.new
   end
 
+  def confirmation_letter_page
+    @last_page = ConfirmationLetterPage.new
+  end
+
   def deregister_page
     @last_page = DeregisterPage.new
   end

--- a/features/page_objects/back_office/confirmation_letter_page.rb
+++ b/features/page_objects/back_office/confirmation_letter_page.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative "sections/admin_menu_section.rb"
+
+class ConfirmationLetterPage < SitePrism::Page
+
+  element(:content, ".wel_letter")
+  element(:heading, "h1")
+  element(:heading_ref, "h1+ h2")
+
+end

--- a/features/page_objects/back_office/dashboard_page.rb
+++ b/features/page_objects/back_office/dashboard_page.rb
@@ -10,8 +10,8 @@ class DashboardPage < SitePrism::Page
 
   element(:content, "#content")
   element(:search_term, "#term")
-  element(:submitted_filter, "#filter_registrations + label")
-  element(:unsubmitted_filter, "#filter_transient_registrations + label")
+  element(:submitted_filter, "#filter_registrations", visible: false)
+  element(:unsubmitted_filter, "#filter_new_registrations", visible: false)
 
   element(:create_new_registration, "a[href='/start/new']")
   element(:change_password, "a[href='/users/password/edit']")
@@ -22,7 +22,7 @@ class DashboardPage < SitePrism::Page
   elements(:results, ".registration-list")
 
   elements(:resume_links, "[id^=resume]")
-  elements(:confirmation_letter_links, "[id^=confirmation_letter_]")
+  elements(:confirmation_letter_links, "a[href*='confirmation-letter']")
 
   def view_link(registration_number)
     find(:css, "#view_#{registration_number}")

--- a/features/page_objects/back_office/dashboard_page.rb
+++ b/features/page_objects/back_office/dashboard_page.rb
@@ -8,6 +8,7 @@ class DashboardPage < SitePrism::Page
 
   section(:admin_menu, AdminMenuSection, AdminMenuSection::SELECTOR)
 
+  element(:content, "#content")
   element(:search_term, "#term")
   element(:submitted_filter, "#filter_registrations + label")
   element(:unsubmitted_filter, "#filter_transient_registrations + label")
@@ -21,6 +22,7 @@ class DashboardPage < SitePrism::Page
   elements(:results, ".registration-list")
 
   elements(:resume_links, "[id^=resume]")
+  elements(:confirmation_letter_links, "[id^=confirmation_letter_]")
 
   def view_link(registration_number)
     find(:css, "#view_#{registration_number}")

--- a/features/page_objects/back_office/edit_details_page.rb
+++ b/features/page_objects/back_office/edit_details_page.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative "sections/admin_menu_section.rb"
+
+class EditDetailsPage < SitePrism::Page
+
+  section(:admin_menu_section, AdminMenuSection, AdminMenuSection::SELECTOR)
+
+  element(:heading, ".heading-large")
+  element(:first_name_form, "#applicant_name_form_first_name")
+  element(:last_name_form, "#applicant_name_form_last_name")
+  element(:operator_name_form, "#operator_name_form_operator_name")
+  element(:contact_email_form_1, "#contact_email_form_contact_email")
+  element(:contact_email_form_2, "#contact_email_form_confirmed_email")
+
+  element(:continue_button, ".button")
+
+  def submit(args = {})
+    first_name_form.set(args[:first_name]) if args.key?(:first_name)
+    last_name_form.set(args[:last_name]) if args.key?(:last_name)
+    operator_name_form.set(args[:operator_name]) if args.key?(:operator_name)
+    contact_email_form_1.set(args[:contact_email]) if args.key?(:contact_email)
+    contact_email_form_2.set(args[:contact_email]) if args.key?(:contact_email)
+    continue_button.click
+  end
+
+end

--- a/features/page_objects/back_office/edit_page.rb
+++ b/features/page_objects/back_office/edit_page.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative "sections/admin_menu_section.rb"
+
+class EditPage < SitePrism::Page
+
+  section(:admin_menu_section, AdminMenuSection, AdminMenuSection::SELECTOR)
+
+  element(:content, "#content")
+  element(:heading, ".heading-large")
+  element(:change_applicant_link, "a[href*='/edit/applicant_name']")
+  element(:change_operator_link, "a[href*='/edit/operator_name']")
+  element(:change_contact_email_link, "a[href*='/edit/contact_email']")
+
+  element(:continue_button, ".button")
+  element(:cancel_link, ".edit_linker a")
+
+end

--- a/features/page_objects/back_office/registration_details_page.rb
+++ b/features/page_objects/back_office/registration_details_page.rb
@@ -7,10 +7,12 @@ class RegistrationDetailsPage < SitePrism::Page
   section(:admin_menu_section, AdminMenuSection, AdminMenuSection::SELECTOR)
 
   element(:heading, ".heading-large")
+  element(:content, "#content")
   element(:deregister_reg_link, ".separated a")
   elements(:active_tags, ".status-tag-active")
   elements(:ceased_tags, ".status-tag-ceased")
   elements(:revoked_tags, ".status-tag-revoked")
   elements(:deregister_ex_links, ".deregister-exemption-button")
+  element(:reporting_info_link, ".govuk-details__summary-text")
 
 end

--- a/features/step_definitions/back_office/edit_steps.rb
+++ b/features/step_definitions/back_office/edit_steps.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+When("I edit the most recent registration") do
+  # Last registration number is stored in @world.last_reference.
+  # Search for the last reference number:
+  @world.bo.dashboard_page.submit(search_term: @world.last_reference)
+  find_link("Edit").click
+  puts "Registration: " + @world.last_reference
+  expect(@world.bo.edit_page.heading).to have_text("Edit " + @world.last_reference + " registration")
+
+  # Generate data using the functions in data_generator.rb
+  @new_details = generate_registration(:limited, nil)
+  @new_person = generate_person
+
+  # Edit the applicant's name to something random
+  @world.bo.edit_page.change_applicant_link.click
+  @world.bo.edit_details_page.submit(
+    first_name: @new_person[:first_name],
+    last_name: @new_person[:last_name]
+  )
+
+  # Edit the operator name
+  @world.bo.edit_page.change_operator_link.click
+  @world.bo.edit_details_page.submit(
+    operator_name: @new_details[:operator_name]
+  )
+
+  # Edit the contact email
+  @world.bo.edit_page.change_contact_email_link.click
+  @world.bo.edit_details_page.submit(
+    contact_email: @new_person[:email]
+  )
+
+end
+
+When("I can see the new details on the registration details page") do
+  @world.bo.registration_details_page.reporting_info_link.click
+  expect(@world.bo.registration_details_page.content).to have_text(@new_person[:first_name])
+  expect(@world.bo.registration_details_page.content).to have_text(@new_person[:last_name])
+  expect(@world.bo.registration_details_page.content).to have_text(@new_person[:email])
+  # The 'not_' in the next line is because of bug RUBY-325:
+  expect(@world.bo.registration_details_page.content).not_to have_text(@new_details[:operator_name])
+  expect(@world.bo.registration_details_page.content).to have_text(@new_person[:first_name])
+end
+
+When("I cannot edit the most recent registration") do
+  @world.bo.dashboard_page.submit(search_term: @world.last_reference)
+  expect(@world.bo.dashboard_page.content).not_to have_text("Edit")
+end
+
+When("I complete the edit") do
+  @world.bo.edit_page.continue_button.click
+  @world.journey.declaration_page.submit
+  expect(@world.bo.edit_details_page.heading).to have_text("Edit complete")
+  @world.bo.edit_details_page.continue_button.click
+  expect(@world.bo.registration_details_page.heading).to have_text("Registration details for " + @world.last_reference)
+end
+
+When("I cancel the edit") do
+  @world.bo.edit_page.cancel_link.click
+  expect(@world.bo.edit_details_page.heading).to have_text("Do you want to cancel this edit?")
+  @world.bo.edit_details_page.continue_button.click
+  expect(@world.bo.edit_details_page.heading).to have_text("Edit cancelled")
+  @world.bo.edit_details_page.continue_button.click
+end
+
+When("I cannot see the new details on the registration details page") do
+  @world.bo.registration_details_page.reporting_info_link.click
+  expect(@world.bo.registration_details_page.content).not_to have_text(@new_person[:first_name])
+  expect(@world.bo.registration_details_page.content).not_to have_text(@new_person[:last_name])
+  expect(@world.bo.registration_details_page.content).not_to have_text(@new_person[:email])
+  expect(@world.bo.registration_details_page.content).not_to have_text(@new_details[:operator_name])
+  expect(@world.bo.registration_details_page.content).not_to have_text(@new_person[:first_name])
+end

--- a/features/step_definitions/back_office/edit_steps.rb
+++ b/features/step_definitions/back_office/edit_steps.rb
@@ -70,5 +70,4 @@ When("I cannot see the new details on the registration details page") do
   expect(@world.bo.registration_details_page.content).not_to have_text(@new_person[:last_name])
   expect(@world.bo.registration_details_page.content).not_to have_text(@new_person[:email])
   expect(@world.bo.registration_details_page.content).not_to have_text(@new_details[:operator_name])
-  expect(@world.bo.registration_details_page.content).not_to have_text(@new_person[:first_name])
 end

--- a/features/step_definitions/back_office/edit_steps.rb
+++ b/features/step_definitions/back_office/edit_steps.rb
@@ -38,8 +38,7 @@ When("I can see the new details on the registration details page") do
   expect(@world.bo.registration_details_page.content).to have_text(@new_person[:first_name])
   expect(@world.bo.registration_details_page.content).to have_text(@new_person[:last_name])
   expect(@world.bo.registration_details_page.content).to have_text(@new_person[:email])
-  # The 'not_' in the next line is because of bug RUBY-325:
-  expect(@world.bo.registration_details_page.content).not_to have_text(@new_details[:operator_name])
+  expect(@world.bo.registration_details_page.content).to have_text(@new_details[:operator_name])
   expect(@world.bo.registration_details_page.content).to have_text(@new_person[:first_name])
 end
 

--- a/features/step_definitions/back_office/search_steps.rb
+++ b/features/step_definitions/back_office/search_steps.rb
@@ -24,12 +24,12 @@ Then("I can see confirmation letter links") do
 end
 
 And("I can see a confirmation letter for a known registration") do
-  # Select the first confirmation letter link for the search term:
-  @world.bo.dashboard_page.confirmation_letter_links[0].click
-
   # As we cannot directly read PDFs through web test automation, use a dedicated URL to view the content as HTML:
-  url = URI.parse(current_url).to_s
-  visit(url + "?show_as_html=true")
+  # Also, when testing headlessly, the direct link to the PDF (first confirmation letter link) doesn't work.
+  # So we need to bypass the PDF link by going directly to the HTML version of the link.
+  # Get target URL from first confirmation letter link and use this to go to the HTML version:
+  letter_html_url = @world.bo.dashboard_page.confirmation_letter_links.first[:href].to_s + "?show_as_html=true"
+  visit(letter_html_url)
 
   # Check confirmation letter with what's been generated in features/support/data_generator.rb :
   expect(@world.bo.confirmation_letter_page.heading).to have_text("Confirmation of waste exemption registration")

--- a/features/step_definitions/back_office/search_steps.rb
+++ b/features/step_definitions/back_office/search_steps.rb
@@ -36,8 +36,8 @@ And("I can see a confirmation letter for a known registration") do
   expect(@world.bo.confirmation_letter_page.heading_ref).to have_text("Your reference: " + @world.known_reg_no.to_s)
   page_content = @world.bo.confirmation_letter_page.content
   expect(page_content).to have_text("Grid reference: SE 09287 25320")
-  expect(page_content).to have_text("Business or organisation type: translation missing: en.organisation_type")
-  expect(page_content).to have_text("Chipping, shredding, cutting or pulverising waste wood")
+  expect(page_content).to have_text("Business or organisation type: Individual or sole trader")
+  expect(page_content).to have_text("waste wood and waste plant matter by chipping, shredding, cutting or pulverising")
 end
 
 Then("I cannot see a confirmation letter") do

--- a/features/step_definitions/back_office/search_steps.rb
+++ b/features/step_definitions/back_office/search_steps.rb
@@ -6,6 +6,8 @@ When("The {string} search filter is selected") do |filter|
 end
 
 When("I search for {string}") do |term|
+  # If using a known registration, take the details generated from features/support/data_generator.rb
+  term = @world.known_reg_no.to_s if term == "a known registration"
   @world.bo.dashboard_page.submit(search_term: term)
 end
 
@@ -15,4 +17,29 @@ end
 
 Then("I don't see {string}") do |unexpected_name|
   expect(page).not_to have_content(unexpected_name)
+end
+
+Then("I can see confirmation letter links") do
+  expect(@world.bo.dashboard_page.confirmation_letter_links.count.positive?).to eq(true)
+end
+
+And("I can see a confirmation letter for a known registration") do
+  # Select the first confirmation letter link for the search term:
+  @world.bo.dashboard_page.confirmation_letter_links[0].click
+
+  # As we cannot directly read PDFs through web test automation, use a dedicated URL to view the content as HTML:
+  url = URI.parse(current_url).to_s
+  visit(url + "?show_as_html=true")
+
+  # Check confirmation letter with what's been generated in features/support/data_generator.rb :
+  expect(@world.bo.confirmation_letter_page.heading).to have_text("Confirmation of waste exemption registration")
+  expect(@world.bo.confirmation_letter_page.heading_ref).to have_text("Your reference: " + @world.known_reg_no.to_s)
+  page_content = @world.bo.confirmation_letter_page.content
+  expect(page_content).to have_text("Grid reference: SE 09287 25320")
+  expect(page_content).to have_text("Business or organisation type: translation missing: en.organisation_type")
+  expect(page_content).to have_text("Chipping, shredding, cutting or pulverising waste wood")
+end
+
+Then("I cannot see a confirmation letter") do
+  expect(@world.bo.dashboard_page.confirmation_letter_links.count).to eq(0)
 end

--- a/features/support/data_generator.rb
+++ b/features/support/data_generator.rb
@@ -53,8 +53,8 @@ end
 
 def generate_site
   {
-    grid_ref: "ST 58132 72695",
-    site_details: "Yer it is"
+    grid_ref: "SE 09287 25320",
+    site_details: "Up north"
   }
 end
 

--- a/features/support/data_generator.rb
+++ b/features/support/data_generator.rb
@@ -28,8 +28,8 @@ def generate_registration(business_type, operator_name = nil)
 end
 
 def generate_person
-  first_name ||= Faker::Name.first_name
-  last_name ||= Faker::Name.last_name
+  first_name ||= Faker::Name.unique.first_name
+  last_name ||= Faker::Name.unique.last_name
 
   {
     first_name: first_name,
@@ -41,7 +41,7 @@ def generate_person
 end
 
 def generate_operator_name(business_type, operator_name)
-  operator_name = "#{Faker::Company.name} Ltd" if business_type == :limited
+  operator_name = "#{Faker::Company.unique.name} Ltd" if business_type == :limited
   operator_name
 end
 

--- a/features/support/registration_helpers.rb
+++ b/features/support/registration_helpers.rb
@@ -55,7 +55,7 @@ def complete_operator_name_and_address(registration)
   @world.journey.operator_name_page.submit(org_name: registration[:operator_name])
   @world.journey.operator_address_page.submit(
     postcode: "BS1 5AH",
-    result: "NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
+    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 end
 
@@ -77,7 +77,7 @@ def complete_contact_details(person)
   @world.journey.contact_email_page.submit(email: person[:email], confirm_email: person[:email])
   @world.journey.contact_address_page.submit(
     postcode: "BS1 5AH",
-    result: "NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
+    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 end
 


### PR DESCRIPTION
Added steps to edit registrations and view confirmation letters, as well as a couple of maintenance updates.

These are fairly straightforward, so I'm not going to request review on this one. Tests and rubocop are passing.