### PR TITLE
Update last-email path

### DIFF
--- a/config/any.config.yml
+++ b/config/any.config.yml
@@ -137,12 +137,12 @@ custom:
     dev:
       front_office: "https://wex-dev.aws.defra.cloud"
       back_office: "https://admin-wex-dev.aws.defra.cloud"
-      mail_client: "https://admin-wex-dev.aws.defra.cloud/last-email"
+      mail_client: "https://admin-wex-dev.aws.defra.cloud/email/last-email"
     tst:
       front_office: "https://wex-tst.aws.defra.cloud"
       back_office: "https://admin-wex-tst.aws.defra.cloud"
-      mail_client: "https://admin-wex-tst.aws.defra.cloud/last-email"
+      mail_client: "https://admin-wex-tst.aws.defra.cloud/email/last-email"
     pre:
       front_office: "https://wex-pre.aws.defra.cloud"
       back_office: "https://admin-wex-pre.aws.defra.cloud"
-      mail_client: "https://admin-wex-pre.aws.defra.cloud/last-email"
+      mail_client: "https://admin-wex-pre.aws.defra.cloud/email/last-email"

--- a/config/dev.config.yml
+++ b/config/dev.config.yml
@@ -123,7 +123,7 @@ custom:
       username: system_user@wex.gov.uk
   urls:
     front_office: "https://wex-dev.aws.defra.cloud"
-    front_office_email: "https://wex-dev.aws.defra.cloud/last-email"
+    front_office_email: "https://wex-dev.aws.defra.cloud/email/last-email"
     back_office: "https://admin-wex-dev.aws.defra.cloud"
-    back_office_email: "https://admin-wex-dev.aws.defra.cloud/last-email"
-    mail_client: "https://wex-dev.aws.defra.cloud/last-email"
+    back_office_email: "https://admin-wex-dev.aws.defra.cloud/email/last-email"
+    mail_client: "https://wex-dev.aws.defra.cloud/email/last-email"

--- a/config/pre.config.yml
+++ b/config/pre.config.yml
@@ -123,7 +123,7 @@ custom:
       username: system_user@wex.gov.uk
   urls:
     front_office: "https://wex-pre.aws.defra.cloud"
-    front_office_email: "https://wex-pre.aws.defra.cloud/last-email"
+    front_office_email: "https://wex-pre.aws.defra.cloud/email/last-email"
     back_office: "https://admin-wex-pre.aws.defra.cloud"
-    back_office_email: "https://admin-wex-pre.aws.defra.cloud/last-email"
-    mail_client: "https://wex-pre.aws.defra.cloud/last-email"
+    back_office_email: "https://admin-wex-pre.aws.defra.cloud/email/last-email"
+    mail_client: "https://wex-pre.aws.defra.cloud/email/last-email"

--- a/config/tst.config.yml
+++ b/config/tst.config.yml
@@ -123,7 +123,7 @@ custom:
       username: system_user@wex.gov.uk
   urls:
     front_office: "https://wex-tst.aws.defra.cloud"
-    front_office_email: "https://wex-tst.aws.defra.cloud/last-email"
+    front_office_email: "https://wex-tst.aws.defra.cloud/email/last-email"
     back_office: "https://admin-wex-tst.aws.defra.cloud"
-    back_office_email: "https://admin-wex-tst.aws.defra.cloud/last-email"
-    mail_client: "https://wex-tst.aws.defra.cloud/last-email"
+    back_office_email: "https://admin-wex-tst.aws.defra.cloud/email/last-email"
+    mail_client: "https://wex-tst.aws.defra.cloud/email/last-email"


### PR DESCRIPTION
The `/last-email` path is a feature in the WEX service which when accessed will return details of the last email sent by an app as JSON.

This is such a useful feature for acceptance testing that we wanted to include it in all our services. So rather than simply copy and paste the same code, we created [defra-ruby-email](https://github.com/DEFRA/defra-ruby-email). It is a rails engine which when mounted into an app and enabled, handles capturing and returning details of the last email sent.

The Waste exemptions service has been updated to use defra-ruby-email but this has meant a slight change in the path to `/last-email`.

This change is just about updating the tests to match.