### PR TITLE
Add developer role to system_tasks tests

### DIFF
--- a/config/ci.config.yml
+++ b/config/ci.config.yml
@@ -13,6 +13,8 @@ custom:
       username: super_agent@wex.gov.uk
     SystemUser:
       username: system_user@wex.gov.uk
+    DeveloperUser:
+      username: developer@wex.gov.uk
   urls:
     front_office: "http://example.com"
     back_office: "http://example.com"

--- a/config/dev.config.yml
+++ b/config/dev.config.yml
@@ -68,6 +68,8 @@ custom:
       username: super_agent@wex.gov.uk
     SystemUser:
       username: system_user@wex.gov.uk
+    DeveloperUser:
+      username: developer@wex.gov.uk
   urls:
     front_office: "https://wex-dev.aws.defra.cloud"
     front_office_email: "https://wex-dev.aws.defra.cloud/email/last-email"

--- a/config/loc.config.yml
+++ b/config/loc.config.yml
@@ -68,6 +68,8 @@ custom:
       username: super_agent@wex.gov.uk
     SystemUser:
       username: system_user@wex.gov.uk
+    DeveloperUser:
+      username: developer@wex.gov.uk
   urls:
     front_office: "http://localhost:3000"
     front_office_email: "http://localhost:3000/email/last-email"

--- a/config/pre.config.yml
+++ b/config/pre.config.yml
@@ -68,6 +68,8 @@ custom:
       username: super_agent@wex.gov.uk
     SystemUser:
       username: system_user@wex.gov.uk
+    DeveloperUser:
+      username: developer@wex.gov.uk
   urls:
     front_office: "https://wex-pre.aws.defra.cloud"
     front_office_email: "https://wex-pre.aws.defra.cloud/email/last-email"

--- a/config/tst.config.yml
+++ b/config/tst.config.yml
@@ -68,6 +68,8 @@ custom:
       username: super_agent@wex.gov.uk
     SystemUser:
       username: system_user@wex.gov.uk
+    DeveloperUser:
+      username: developer@wex.gov.uk
   urls:
     front_office: "https://wex-tst.aws.defra.cloud"
     front_office_email: "https://wex-tst.aws.defra.cloud/email/last-email"

--- a/features/back_office/edit.feature
+++ b/features/back_office/edit.feature
@@ -1,4 +1,4 @@
-@backoffice @edit
+@backoffice @edit @smoke
 Feature: Back office user edits a registration
   As an super admin agent
   I need to edit a waste exemption registration

--- a/features/back_office/renew.feature
+++ b/features/back_office/renew.feature
@@ -1,4 +1,4 @@
-@backoffice @renew @renewb
+@backoffice @renew @renewb @smoke
 Feature: [RUBY-241] Back office user carries out a renewal
   As an admin agent
   I need to renew on behalf of an assisted digital user

--- a/features/back_office/system_tasks.feature
+++ b/features/back_office/system_tasks.feature
@@ -6,68 +6,86 @@ Feature: Carry out system tasks
 
   @email
   Scenario: System user adds a new user
-	  Given I sign in as a system user
-     When I invite a new back office user
-      And the invite is accepted
-     Then a password is set
-      And the new back office user can sign in
-      And the new back office user cannot change their password
+    Given I sign in as a system user
+    When I invite a new back office user
+    And the invite is accepted
+    Then a password is set
+    And the new back office user can sign in
+    And the new back office user cannot change their password
 
-  Scenario: System user changes a users role
-	  Given I sign in as a system user
-     When I change a users role to super agent
-     Then I see their role has changed
+  Scenario: System user changes a user's role
+    Given I sign in as a system user
+    When I change a users role to super agent
+    Then I see their role has changed
 
   Scenario: System user deactivates a user
-	  Given I sign in as a system user
-     When I deactivate a user
-     Then I see their status has changed
+    Given I sign in as a system user
+    When I deactivate a user
+    Then I see their status has changed
 
   Scenario: User is a system_user
     Given I sign in as a system user
-     Then I can access the user management screen
-      And I will have the option to create a new registration
-      And I can access create a new registration
-      And I can search for registrations
-      And I can view their details
-      And I can continue an in progress registration
-      And I can access data exports
-      And I can download letters
+    Then I can access the user management screen
+    And I will have the option to create a new registration
+    And I can access create a new registration
+    And I can search for registrations
+    And I can view their details
+    And I can continue an in progress registration
+    And I can access data exports
+    And I can download letters
+    But I cannot toggle features
 
   Scenario: User is a super_agent
     Given I sign in as a super agent
-     Then I will not have the option to manage users
-      And I cannot access the user management screen
-      But I will have the option to create a new registration
-      And I can access create a new registration
-      But I can search for registrations
-      And I can view their details
-      And I can continue an in progress registration
-      And I can access data exports
-      And I can download letters
+    Then I will not have the option to manage users
+    And I cannot access the user management screen
+    But I will have the option to create a new registration
+    And I can access create a new registration
+    But I can search for registrations
+    And I can view their details
+    And I can continue an in progress registration
+    And I can access data exports
+    And I can download letters
+    But I cannot toggle features
 
   Scenario: User is an admin_agent
     Given I sign in as an admin agent
-     Then I will not have the option to manage users
-      And I cannot access the user management screen
-      But I will have the option to create a new registration
-      And I can access create a new registration
-      And I can search for registrations
-      And I can view their details
-      And I can continue an in progress registration
-      And I can access data exports
-      And I can download letters
-      But I cannot edit the most recent registration
+    Then I will not have the option to manage users
+    And I cannot access the user management screen
+    But I will have the option to create a new registration
+    And I can access create a new registration
+    And I can search for registrations
+    And I can view their details
+    And I can continue an in progress registration
+    And I can access data exports
+    And I can download letters
+    But I cannot toggle features
+    And I cannot edit the most recent registration
 
   Scenario: User is a data_agent
-    Given I sign in as an data agent
-     Then I will not have the option to manage users
-      And I cannot access the user management screen
-      And I will not have the option to create a new registration
-      And I cannot access create a new registration
-      But I can search for registrations
-      And I can view their details
-      But I cannot continue an in progress registration
-      But I can access data exports
-      But I cannot edit the most recent registration
-      But I cannot download letters
+    Given I sign in as a data agent
+    Then I will not have the option to manage users
+    And I cannot access the user management screen
+    And I will not have the option to create a new registration
+    And I cannot access create a new registration
+    But I can search for registrations
+    And I can view their details
+    But I cannot continue an in progress registration
+    But I can access data exports
+    But I cannot edit the most recent registration
+    But I cannot download letters
+    But I cannot toggle features
+
+  Scenario: User is a developer
+    Given I sign in as a developer
+    Then I will not have the option to manage users
+    And I cannot access the user management screen
+    But I will have the option to create a new registration
+    And I can access create a new registration
+    And I can search for registrations
+    And I can view their details
+    And I can continue an in progress registration
+    And I can access data exports
+    And I can download letters
+    And I can toggle features
+    But I cannot edit the most recent registration

--- a/features/page_objects/back_office/sections/admin_menu_section.rb
+++ b/features/page_objects/back_office/sections/admin_menu_section.rb
@@ -11,5 +11,6 @@ class AdminMenuSection < SitePrism::Section
   element(:dashboard_link, "li:nth-child(1) a")
   element(:download_letters_link, "a[href*='/letters']")
   element(:data_exports, "a[href*='/data-exports']")
+  element(:toggle_features_link, "a[href*='/features/feature-toggles']")
 
 end

--- a/features/step_definitions/back_office/sign_in_steps.rb
+++ b/features/step_definitions/back_office/sign_in_steps.rb
@@ -12,6 +12,10 @@ Given(/^I sign in as (?:a|an) admin agent$/) do
   login_user(@world.admin_agent_user)
 end
 
-Given(/^I sign in as (?:a|an) data agent$/) do
+Given(/^I sign in as a data agent$/) do
   login_user(@world.data_agent_user)
+end
+
+Given(/^I sign in as a developer$/) do
+  login_user(@world.developer_user)
 end

--- a/features/step_definitions/back_office/user_roles_steps.rb
+++ b/features/step_definitions/back_office/user_roles_steps.rb
@@ -96,3 +96,12 @@ end
 Then("I cannot download letters") do
   expect(@world.bo.dashboard_page.admin_menu).to have_no_download_letters_link
 end
+
+Then("I can toggle features") do
+  @world.bo.dashboard_page.admin_menu.toggle_features_link.click
+  expect(@world.journey.standard_page.heading).to have_text("Feature Toggles")
+end
+
+Then("I cannot toggle features") do
+  expect(@world.bo.dashboard_page.admin_menu).to have_no_toggle_features_link
+end

--- a/features/support/world.rb
+++ b/features/support/world.rb
@@ -30,6 +30,10 @@ class World
     Quke::Quke.config.custom["accounts"]["SystemUser"]["username"]
   end
 
+  def developer_user
+    Quke::Quke.config.custom["accounts"]["DeveloperUser"]["username"]
+  end
+
   def default_password
     ENV["WEX_DEFAULT_PASSWORD"]
   end


### PR DESCRIPTION
This PR:

- adds a developer role to the test data
- tests its permissions in the system_tasks test
- beautifies the user permissions feature

The new test passes - it is independent of other tests. Rubocop is happy.