### PR TITLE
Add accessibility tests using Axe

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "pry"
 gem "rake"
 gem "axe-core-capybara"
 gem "axe-core-rspec"
+gem "axe-core-selenium"
 gem "axe-core-cucumber"
 gem "rspec-core"
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,9 @@ gem "quke",
 gem "faker"
 gem "pry"
 gem "rake"
+gem "axe-core-capybara"
+gem "axe-core-rspec"
+gem "axe-core-cucumber"
 
 # Gem used by the Defra ruby services team to ensure a consistent style across
 # our code base

--- a/Gemfile
+++ b/Gemfile
@@ -6,19 +6,19 @@ gem "quke",
     git: "https://github.com/DEFRA/quke",
     branch: "main"
 
-# Rake gives us the ability to create our own commands or 'tasks' for working
-# with quke.
-
-# Create random names
-gem "faker"
-gem "pry"
-gem "rake"
+# Test for accessibility:
 gem "axe-core-capybara"
-gem "axe-core-rspec"
-gem "axe-core-selenium"
 gem "axe-core-cucumber"
-gem "rspec-core"
 
 # Gem used by the Defra ruby services team to ensure a consistent style across
 # our code base
 gem "defra_ruby_style"
+
+# Create random names:
+gem "faker"
+
+# Debug tests with binding.pry:
+gem "pry"
+
+# Run tasks:
+gem "rake"

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "rake"
 gem "axe-core-capybara"
 gem "axe-core-rspec"
 gem "axe-core-cucumber"
+gem "rspec-core"
 
 # Gem used by the Defra ruby services team to ensure a consistent style across
 # our code base

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,13 +32,6 @@ GEM
       axe-core-api
       dumb_delegator
       virtus
-    axe-core-rspec (4.0.0)
-      axe-core-api
-      dumb_delegator
-      virtus
-    axe-core-selenium (4.0.0)
-      axe-core-api
-      dumb_delegator
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
@@ -111,8 +104,6 @@ GEM
     rake (13.0.1)
     regexp_parser (1.7.1)
     rexml (3.2.4)
-    rspec-core (3.9.3)
-      rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
@@ -161,14 +152,11 @@ PLATFORMS
 DEPENDENCIES
   axe-core-capybara
   axe-core-cucumber
-  axe-core-rspec
-  axe-core-selenium
   defra_ruby_style
   faker
   pry
   quke!
   rake
-  rspec-core
 
 BUNDLED WITH
    2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,9 @@ GEM
       axe-core-api
       dumb_delegator
       virtus
+    axe-core-selenium (4.0.0)
+      axe-core-api
+      dumb_delegator
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
@@ -159,6 +162,7 @@ DEPENDENCIES
   axe-core-capybara
   axe-core-cucumber
   axe-core-rspec
+  axe-core-selenium
   defra_ruby_style
   faker
   pry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,8 @@ GEM
     rake (13.0.1)
     regexp_parser (1.7.1)
     rexml (3.2.4)
+    rspec-core (3.9.3)
+      rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
@@ -162,6 +164,7 @@ DEPENDENCIES
   pry
   quke!
   rake
+  rspec-core
 
 BUNDLED WITH
    2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,27 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
+    axe-core-api (4.0.0)
+      capybara
+      dumb_delegator
+      selenium-webdriver
+      virtus
+      watir
+    axe-core-capybara (4.0.0)
+      axe-core-api
+      dumb_delegator
+    axe-core-cucumber (4.0.0)
+      axe-core-api
+      dumb_delegator
+      virtus
+    axe-core-rspec (4.0.0)
+      axe-core-api
+      dumb_delegator
+      virtus
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     backports (3.18.1)
     browserstack-local (1.3.0)
     builder (3.2.4)
@@ -32,6 +53,8 @@ GEM
       xpath (~> 3.2)
     childprocess (3.0.0)
     coderay (1.1.3)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.1.7)
     cucumber (3.2.0)
       builder (>= 2.1.2)
@@ -51,12 +74,17 @@ GEM
     cucumber-wire (0.0.1)
     defra_ruby_style (0.2.2)
       rubocop (~> 0.82)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.4.4)
+    dumb_delegator (1.0.0)
+    equalizer (0.0.11)
     faker (2.14.0)
       i18n (>= 1.6, < 2)
     gherkin (5.1.0)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     launchy (2.5.0)
       addressable (~> 2.7)
     method_source (1.0.0)
@@ -105,7 +133,16 @@ GEM
       capybara (~> 3.3)
       site_prism-all_there (>= 0.3.1, < 1.0)
     site_prism-all_there (0.3.2)
+    thread_safe (0.3.6)
     unicode-display_width (1.7.0)
+    virtus (1.0.5)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
+    watir (6.17.0)
+      regexp_parser (~> 1.2)
+      selenium-webdriver (~> 3.6)
     webdrivers (4.4.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -117,6 +154,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  axe-core-capybara
+  axe-core-cucumber
+  axe-core-rspec
   defra_ruby_style
   faker
   pry

--- a/README.md
+++ b/README.md
@@ -127,14 +127,13 @@ Next up if the scenario is in a feature with a `Background` defined the steps in
 
 This repository includes the ability to check the currently loaded page for accessibility violations. It uses [axe-core-capybara](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-capybara/) and [axe-core-cucumber](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-cucumber).
 
-To call it, use:
+To call it, use the following step:
 
-```
-# as an entire step - this works:
+```gherkin
 Then the page should be axe clean
 
-# within a step - this doesn't work yet:
-expect(page).to be_axe_clean
+# or call this within another step using
+step("the page should be axe clean")
 ```
 
 This calls all of Axe's accessibility rules and is useful to find best practice. However, our minimum standard is to focus on Web Content Accessibility Guidelines v2.1 to levels A and AA, so we want the tests to pass if so. Use this step to reduce the scope:

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ To have consistency across the project the following tags are defined and should
 |@ci|A feature that is intended to be run only on our continuous integration service (you should never need to use this tag).|
 |@email|Tests scenarios which include steps that interact with an email client|
 |@data|Steps that rely on pre-existing data being generated|
+|@smoke|Core tests to check that registrations and renewals on the front and back office are working|
 
 Each test also has its own unique tag in case it needs to be run in isolation.
 
@@ -108,7 +109,7 @@ This hopefully will help new starters to the project and Cucumber understand the
 
 ### Before hooks
 
-Before the scenario runs any [before hooks](https://docs.cucumber.io/cucumber/api/#before) defined in the project will be run. In this project we currently have 3
+Before the scenario runs any [before hooks](https://docs.cucumber.io/cucumber/api/#before) defined in the project will be run. In this project we currently have 3:
 
 - One that always runs, which is used to copy the global `$world_state` to an instance used for the current run
 - One that if the scenario is tagged `@data` will generate some registrations and a user. Logic in the hook ensures this is only run once, and is used as a handy way of having known data that can be used across multiple scenarios
@@ -121,6 +122,30 @@ However when the scenario finishes `@my_var` will no longer hold anything. So to
 ### Background
 
 Next up if the scenario is in a feature with a `Background` defined the steps in it will be run first. Only then will the scenario itself be run.
+
+### Accessibility
+
+This repository includes the ability to check the currently loaded page for accessibility violations. It uses [axe-core-capybara](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-capybara/) and [axe-core-cucumber](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-cucumber).
+
+To call it, use:
+
+```
+# as an entire step - this works:
+Then the page should be axe clean
+
+# within a step - this doesn't work yet:
+expect(page).to be_axe_clean
+```
+
+This calls all of Axe's accessibility rules and is useful to find best practice. However, our minimum standard is to focus on Web Content Accessibility Guidelines v2.1 to levels A and AA, so we want the tests to pass if so. Use this step to reduce the scope:
+
+```gherkin
+Then the page should be axe clean according to: wcag21a, wcag21aa
+```
+
+Also refer to [Axe API documentation](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md) for more detail.
+
+Finally, remember that automated testing is not a substitute for manual testing.
 
 ### After hooks
 
@@ -142,7 +167,6 @@ You can also test them using the Chrome developer tools. Open them up, select th
 If you have an idea you'd like to contribute please log an issue.
 
 All contributions should be submitted via a pull request.
-
 
 ## License
 

--- a/features/front_office/create_registration.feature
+++ b/features/front_office/create_registration.feature
@@ -11,9 +11,9 @@ Feature: Registering a waste exemption
       Then I will be informed the registration is complete
       And I can access the footer links
 
-    Scenario: Registration by a limited company with errors
+    Scenario: Registration by a limited company with error validation
       Given my business is a "limited_company"
-      When I complete a registration badly
+      When I register and test validation and accessibility
       Then I will be informed the registration is complete
 
     Scenario: Registration by a local authority

--- a/features/front_office/create_registration.feature
+++ b/features/front_office/create_registration.feature
@@ -4,17 +4,17 @@ Feature: Registering a waste exemption
   I want to register a waste activity exemption
   So that know that I am complying with regulations
 
-  @smoke
     Scenario: Registration by an individual
       Given my business is an "individual"
       When I register an exemption
       Then I will be informed the registration is complete
-      And I can access the footer links
 
+  @smoke
     Scenario: Registration by a limited company with error validation
       Given my business is a "limited_company"
       When I register and test validation and accessibility
       Then I will be informed the registration is complete
+      And I can access the footer links
 
     Scenario: Registration by a local authority
       Given my business is a "local_authority"

--- a/features/front_office/create_registration.feature
+++ b/features/front_office/create_registration.feature
@@ -6,47 +6,32 @@ Feature: Registering a waste exemption
 
   @smoke
     Scenario: Registration by an individual
-     Given my business is an "individual"
+      Given my business is an "individual"
       When I register an exemption
       Then I will be informed the registration is complete
-       And I can access the footer links
+      And I can access the footer links
 
-    Scenario: Registration by a partnership
-     Given my business is a "partnership"
-      When I register an exemption
+    Scenario: Registration by a limited company with errors
+      Given my business is a "limited_company"
+      When I complete a registration badly
       Then I will be informed the registration is complete
-
-    Scenario: Registration by an LLP
-      Given my business is an "llp"
-       When I register an exemption
-       Then I will be informed the registration is complete
 
     Scenario: Registration by a local authority
       Given my business is a "local_authority"
-       When I register an exemption
-       Then I will be informed the registration is complete
+      When I register an exemption
+      Then I will be informed the registration is complete
 
     Scenario: Registration by a charity
       Given my business is a "charity"
-       When I register an exemption
-       Then I will be informed the registration is complete
-
-    Scenario: Registration by a limited company
-      Given my business is a "limited_company"
-       When I register an exemption
-       Then I will be informed the registration is complete
-
-    Scenario: Generate errors on the front office
-      Given my business is a "limited_company"
-       When I complete a registration badly
-       Then I will be informed the registration is complete
+      When I register an exemption
+      Then I will be informed the registration is complete
 
     Scenario: Choose locations outside England
       Given I start a new waste exemption registration
-       When I choose locations outside England
-       Then I will be advised to register with another authority
+      When I choose locations outside England
+      Then I will be advised to register with another authority
 
     Scenario: Select option to change details
       Given I am on the service
-       When I select the option to change details
-       Then I will be advised to contact the EA
+      When I select the option to change details
+      Then I will be advised to contact the EA

--- a/features/front_office/renew.feature
+++ b/features/front_office/renew.feature
@@ -11,7 +11,6 @@ Feature: [RUBY-241] Front office user renews a registration via email
     Given my business is a "limited_company"
      When I register an exemption
      Then I will be informed the registration is complete
-
       And I receive an invitation to renew
       And I click the link in the renewal email
 
@@ -36,5 +35,5 @@ Feature: [RUBY-241] Front office user renews a registration via email
      Then I can resume the renewal from where I left off
 
   Scenario: Renewal errors
-     When I renew the registration badly
+     When I renew and test validation and accessibility
      Then I see the renewal confirmation screen

--- a/features/step_definitions/journey/registration_steps.rb
+++ b/features/step_definitions/journey/registration_steps.rb
@@ -14,7 +14,7 @@ end
 
 Then("I will be informed the registration is complete") do
   expect(page).to have_content "Registration complete"
-  # todo - add an email check here
+  # Also recommend adding an email check here
 end
 
 Then(/^I complete (?:a|an) "([^"]*)" registration$/) do |business|

--- a/features/step_definitions/journey/registration_steps.rb
+++ b/features/step_definitions/journey/registration_steps.rb
@@ -14,6 +14,7 @@ end
 
 Then("I will be informed the registration is complete") do
   expect(page).to have_content "Registration complete"
+  # todo - add an email check here
 end
 
 Then(/^I complete (?:a|an) "([^"]*)" registration$/) do |business|

--- a/features/step_definitions/journey/validation_steps.rb
+++ b/features/step_definitions/journey/validation_steps.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-Given "I complete a registration badly" do
+Given "I register and test validation and accessibility" do
+  # This step checks validation throughout the journey as well as testing the main pages for accessibility.
+
   # add_submitted_registration
   @world.journey.home_page.load
   reg = @world.last_reg # shorthand for the registration data that has been generated
@@ -8,23 +10,26 @@ Given "I complete a registration badly" do
   # Start page
   @world.journey.registration_type_page.submit_button.click
   expect(@world.journey.registration_type_page.error).to have_text("You must answer this question")
+  check_for_accessibility
   @world.journey.registration_type_page.submit(start_option: :new_radio)
 
   # Location page
   @world.journey.location_page.submit_button.click
   expect(@world.journey.location_page.error).to have_text("You must answer this question")
+  check_for_accessibility
   @world.journey.location_page.submit(location: :england)
 
   # Extra check that going back doesn't trigger a 404 error, based on RUBY-562
   page.evaluate_script("window.history.back()")
   expect(@world.journey.location_page.heading).to have_text("In which country will you use the exemptions?")
+  check_for_accessibility
   @world.journey.location_page.submit(location: :england)
 
   test_journey_validations(reg, "new")
 
 end
 
-Given "I renew the registration badly" do
+Given "I renew and test validation and accessibility" do
 
   # Renew with or without changes screen:
   expect(@world.journey.renew_choice_page.heading).to have_text("Do you want to renew with these details?")
@@ -32,11 +37,13 @@ Given "I renew the registration badly" do
   expect(@world.journey.renew_choice_page.content).to have_text("U12 - Using mulch")
   @world.journey.renew_choice_page.continue_button.click
   expect(@world.journey.renew_choice_page.error).to have_text("Select if you want to renew with these details")
+  check_for_accessibility
 
   # Firstly, select 'no changes':
   @world.journey.renew_choice_page.renew_without_changes_radio.click
   @world.journey.renew_choice_page.continue_button.click
   expect(@world.journey.renew_splash_page.heading).to have_text("You are about to renew for 3 years")
+  check_for_accessibility
 
   # Go back and select 'with changes'
   @world.journey.renew_splash_page.back_link.click
@@ -48,6 +55,7 @@ Given "I renew the registration badly" do
   @changes = "with"
 
   expect(@world.journey.renew_splash_page.heading).to have_text("We'll fill in the form")
+  check_for_accessibility
   @world.journey.renew_splash_page.continue_button.click
 
   # Location page. Can't generate an error here because a value is prepropulated.
@@ -61,6 +69,7 @@ end
 Then "I see the renewal confirmation screen" do
 
   expect(@world.journey.confirmation_page.confirmation_box).to have_text("You have renewed your exemptions")
+  check_for_accessibility
   @renewed_reg_no = @world.journey.confirmation_page.ref_no.text
   puts @world.last_reg_no + " renewed with changes. New registration is " + @renewed_reg_no + "."
 

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -7,3 +7,7 @@ end
 def front_office_root_url(path = "")
   File.join(@world.front_office_url, path)
 end
+
+def check_for_accessibility
+  step("the page should be axe clean according to: wcag21a, wcag21aa")
+end

--- a/features/support/validation_helpers.rb
+++ b/features/support/validation_helpers.rb
@@ -30,6 +30,7 @@ def test_exemption_validations(reg, reg_type)
   end
 
   expect(@world.journey.choose_exemptions_page.error).to have_text("You must select at least one exemption")
+  check_for_accessibility
   @world.journey.choose_exemptions_page.submit(exemptions: reg[:exemptions])
 end
 
@@ -44,6 +45,7 @@ def test_name_validations(person)
   @world.journey.name_page.submit(first_name: "", last_name: "")
   expect(@world.journey.name_page.error).to have_text("You must enter a first name")
   expect(@world.journey.name_page.error).to have_text("You must enter a last name")
+  check_for_accessibility
   @world.journey.name_page.submit(
     first_name: person[:first_name],
     last_name: person[:last_name]
@@ -54,6 +56,7 @@ def test_phone_validations(phone_no)
   # Tests validations on applicant and contact phone number pages.
   @world.journey.phone_page.submit(tel_no: "")
   expect(@world.journey.phone_page.error).to have_text("Enter a telephone number")
+  check_for_accessibility
   @world.journey.phone_page.submit(tel_no: phone_no)
 end
 
@@ -65,6 +68,7 @@ def test_email_validations(email_address)
     confirm_email: "b@example.com"
   )
   expect(@world.journey.email_page.error).to have_text("The email addresses you’ve entered don’t match")
+  check_for_accessibility
   @world.journey.email_page.submit(
     email: email_address,
     confirm_email: email_address
@@ -82,6 +86,7 @@ def test_operator_type_validations(reg, reg_type)
   # Company registration number page
   @world.journey.registration_number_page.submit(registration_number: "")
   expect(@world.journey.registration_number_page.error).to have_text("Enter a company registration number")
+  check_for_accessibility
   @world.journey.registration_number_page.submit(registration_number: reg[:registration_number])
 end
 
@@ -93,6 +98,7 @@ def test_operator_name_address_validation(operator_name, reg_type)
 
   # Operator address page
   expect(@world.journey.address_lookup_page.heading).to have_text("What's the company address?")
+  check_for_accessibility
   # Generate errors on the address pages with the given text in the postcode field:
   test_address_validations("ROSS KEMP", reg_type)
 end
@@ -118,6 +124,7 @@ end
 def leave_postcode_blank
   @world.journey.address_lookup_page.enter_postcode("")
   expect(@world.journey.address_lookup_page.error).to have_text("Enter a postcode")
+  check_for_accessibility
 end
 
 def dont_select_address_from_dropdown
@@ -126,6 +133,7 @@ def dont_select_address_from_dropdown
   @world.journey.address_lookup_page.enter_postcode("BS1 5AH")
   @world.journey.address_lookup_page.submit_button.click
   expect(@world.journey.address_lookup_page.error).to have_text("You must select an address")
+  check_for_accessibility
   find_link("Change postcode").click
 end
 
@@ -133,6 +141,7 @@ def enter_invalid_postcode(postcode_text)
   @world.journey.address_lookup_page.enter_postcode(postcode_text)
   @world.journey.address_lookup_page.find_address.click
   expect(@world.journey.address_lookup_page.error).to have_text("Enter a valid UK postcode")
+  check_for_accessibility
 end
 
 def test_address_manual_validation
@@ -149,6 +158,7 @@ def test_address_manual_validation
   expect(@world.journey.address_manual_page.error).to have_text("Enter the building name or number")
   expect(@world.journey.address_manual_page.error).to have_text("Enter an address line 1")
   expect(@world.journey.address_manual_page.error).to have_text("Enter a town or city")
+  check_for_accessibility
 
   # Enter valid details:
   @world.journey.address_manual_page.submit_manual_address(
@@ -170,6 +180,7 @@ def test_contact_validations(contact, reg_type)
   test_phone_validations(contact[:telephone])
   test_email_validations(contact[:email])
   expect(@world.journey.address_lookup_page.heading).to have_text("What's their postcode?")
+  check_for_accessibility
   test_address_validations("STEVE MCFADDEN", reg_type)
 end
 
@@ -186,6 +197,7 @@ def test_farm_validations(reg, reg_type)
   return unless reg_type == "new"
 
   expect(@world.journey.farmer_page.error).to have_text("You must answer this question")
+  check_for_accessibility
   @world.journey.farmer_page.submit(farmer: reg[:farmer])
 end
 
@@ -196,6 +208,7 @@ def test_site_validations(reg_type)
     @world.journey.site_grid_reference_page.submit(grid_ref: "", site_details: "")
     expect(@world.journey.site_grid_reference_page.error).to have_text("Enter a grid reference")
     expect(@world.journey.site_grid_reference_page.error).to have_text("Enter a site description")
+    check_for_accessibility
     find_link("use an address instead").click
   end
 
@@ -212,5 +225,6 @@ def test_confirmation_validations
   # rubocop:disable Layout/LineLength
   expect(@world.journey.declaration_page.error).to have_text("You cannot register if you do not understand and agree with the declaration")
   # rubocop:enable Layout/LineLength
+  check_for_accessibility
   @world.journey.declaration_page.submit
 end

--- a/features/support/world.rb
+++ b/features/support/world.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require "axe-cucumber-steps"
+require "axe-capybara"
+require "axe-rspec"
+
 class World
 
   attr_reader :journey, :bo, :email

--- a/features/support/world.rb
+++ b/features/support/world.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "axe-cucumber-steps"
-require "axe-capybara"
-require "axe-rspec"
-
 class World
+
+  require "axe-cucumber-steps"
+  require "axe-capybara"
+  require "axe-rspec"
 
   attr_reader :journey, :bo, :email
 

--- a/features/support/world.rb
+++ b/features/support/world.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
-class World
+require "axe-cucumber-steps"
+require "axe-capybara"
+require "axe-rspec"
+require "axe-selenium"
 
-  require "axe-cucumber-steps"
-  require "axe-capybara"
-  require "axe-rspec"
+class World
 
   attr_reader :journey, :bo, :email
 

--- a/features/support/world.rb
+++ b/features/support/world.rb
@@ -2,8 +2,6 @@
 
 require "axe-cucumber-steps"
 require "axe-capybara"
-require "axe-rspec"
-require "axe-selenium"
 
 class World
 


### PR DESCRIPTION
This PR:
- Adds `axe-core-capybara` and `axe-core-cucumber` gems into the repo
- Includes Cucumber steps to test for accessibility during registrations
- Tidies up the registration feature

Although I can't currently run the full test suite as we are rebuilding /last-email, smoke tests and the updated registration test pass (and produce meaningful results to the terminal if there's a failure).

Ideally I would have used [axe-core-rspec](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-rspec/README.md) so that I could have used `expect(page).to be_axe_clean` . This appears more elegant, but I struggled to get this working using the guidance provided.

However, the current solution uses a similar number of lines of code and has the same effect, so I'm happy with it.