### PR TITLE
Switch to using GitHub actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on: push
+
+jobs:
+  build:
+    # You must use a Linux environment when using service containers or container jobs
+    runs-on: ubuntu-latest
+
+    steps:
+      # Downloads a copy of the code in your repository before running CI tests
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
+
+      # Check for 'temporary' tags i.e. tags often used when working on a feature/scenario but which we don't want
+      # appearing in the final commit to main
+      #
+      # Reworking of https://stackoverflow.com/a/21788642/6117745
+      - name: Temporary tag check
+        run: |
+          ! grep -r --include="*.feature" "@wip\|@focus" features/
+
+      # We don't have to specify the ruby version, or grab it from .ruby-verion. This action supports reading the
+      # version from .ruby-verion itself
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      # Run linting first. No point running the tests if there is a linting issue
+      - name: Run lint check
+        run: |
+          bundle exec rubocop
+
+      # We don't have unit tests in this project. We also can't access the service as its hidden behind a VPN. Instead
+      # we run a special CI test to confirm we haven't broken being able to run the project
+      - name: Run build test
+        run: |
+          bundle exec rake ci

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Waste exemptions acceptance tests
 
-[![Build Status](https://travis-ci.com/DEFRA/waste-exemptions-acceptance-tests.svg?branch=main)](https://travis-ci.com/DEFRA/waste-exemptions-acceptance-tests)
+![Build Status](https://github.com/DEFRA/waste-exemptions-acceptance-tests/workflows/CI/badge.svg?branch=main)
 [![security](https://hakiri.io/github/DEFRA/waste-exemptions-acceptance-tests/main.svg)](https://hakiri.io/github/DEFRA/waste-exemptions-acceptance-tests/main)
 
 If your business produces waste or emissions that pollute you may require an environmental permit. However you may also be able to get an exemption if your business activities are considered to be easily controlled and only create low risks of pollution.


### PR DESCRIPTION
https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
https://www.jeffgeerling.com/blog/2020/travis-cis-new-pricing-plan-threw-wrench-my-open-source-works

On Nov 2 Travis-CI introduced a new pricing model for their free tier offering. Those on this tier would now be limited to 1000 build minutes a month. This would start to be rolled out across accounts imminently. Defra's seems to have been updated November 9 because by the end of the day all builds stopped. When you went to Travis-CI a message was shown stating

> Builds have been temporarily disabled for private and public repositories due to a negative credit balance. Please go to the Plan page to replenish your credit balance.

It's going to take some time to decide and agree whether we will move to a paid-for option, or choose to start rolling our own. We don't like the idea of having no automated CI during this unknown period. A number of people caught up in this change have suggested [GitHub Actions](https://docs.github.com/en/free-pro-team@latest/actions) as an alternative.

So this change moves the project from Travis to GitHub to handle our CI