### PR TITLE
Changing org type on renewal scenario

### DIFF
--- a/features/front_office/renew.feature
+++ b/features/front_office/renew.feature
@@ -28,3 +28,7 @@ Feature: [RUBY-241] Front office user renews a registration via email
       And I receive a renewal confirmation email
       And I cannot renew it again from the front office
       And I cannot renew it again from the back office
+
+  Scenario: Changing organisation type during renewal prompts user to create a new registration
+    When I renew changing my organisation type
+    Then I am informed I will need a new registration

--- a/features/page_objects/apps/journey_app.rb
+++ b/features/page_objects/apps/journey_app.rb
@@ -131,4 +131,8 @@ class JourneyApp
     @last_page = SiteGridReferencePage.new
   end
 
+  def can_not_renew_type_page
+    @last_page = CanNotRenewTypePage.new
+  end
+
 end

--- a/features/page_objects/journey/can_not_renew_type_page.rb
+++ b/features/page_objects/journey/can_not_renew_type_page.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CanNotRenewTypePage < BasePage
+
+  element(:new_registration_option, "a[href='/start']")
+
+  def submit
+    new_registration_option.click
+  end
+
+end

--- a/features/step_definitions/journey/renew_steps.rb
+++ b/features/step_definitions/journey/renew_steps.rb
@@ -93,6 +93,24 @@ When("I renew the registration {string} changes") do |changes|
 
 end
 
+When("I renew changing my organisation type") do
+  @world.journey.check_registered_company_name_page.submit(choice: :confirm) if company?
+  @renewed_reg = generate_registration(@business_type, nil)
+
+  @world.journey.renew_choice_page.renew_with_changes_radio.click
+  @world.journey.renew_choice_page.submit
+
+  # rubocop:disable Layout/LineLength
+  expect(@world.journey.renew_splash_page.heading).to have_text("We'll fill in the form with your current registration details")
+  # rubocop:enable Layout/LineLength
+  @world.journey.renew_splash_page.submit
+  @world.journey.location_page.submit(location: :england)
+  @world.journey.choose_exemptions_page.submit
+  complete_applicant_details(@renewed_reg[:applicant])
+
+  @world.journey.business_type_page.submit(business_type: :individual)
+end
+
 Then("I can see the correct renewed details") do
   # Search for the renewed registration in back office.
   # Should already be logged in as a back office user:
@@ -179,4 +197,9 @@ Then("a renewal reminder letter has been sent") do
     "Registration details for registration number " + @world.last_reg_no.to_s
   ]
   expect(letter_exists?(expected_text)).to be true
+end
+
+Then("I am informed I will need a new registration") do
+  expect(@world.journey.can_not_renew_type_page.heading).to have_text("You need a new registration")
+  expect(@world.journey.can_not_renew_type_page).to have_new_registration_option
 end


### PR DESCRIPTION
Changing org type during renewal prompts user to create a new registration